### PR TITLE
Add prefix to copied types and constants

### DIFF
--- a/com/a3d.c
+++ b/com/a3d.c
@@ -25,13 +25,13 @@ typedef struct {
   uint16_t nBlockAlign;
   uint16_t wBitsPerSample;
   uint16_t cbSize;
-} WAVEFORMATEX;
+} API(WAVEFORMATEX);
 
 typedef struct {
   void* vtable;
   ALuint al_source;
   ALuint al_buffer;
-  WAVEFORMATEX fmt;
+  API(WAVEFORMATEX) fmt;
   Address data;
 } A3DSOURCE;
 
@@ -204,7 +204,7 @@ HACKY_COM_BEGIN(IA3d4, 0)
   hacky_printf("a 0x%" PRIX32 "\n", stack[2]);
   hacky_printf("b 0x%" PRIX32 "\n", stack[3]);
 
-  const IID* iid = (const IID*)Memory(stack[2]);
+  const API(IID)* iid = (const API(IID)*)Memory(stack[2]);
 
   char iidString[1024];
   sprintf(iidString, "%08" PRIX32 "-%04" PRIX16 "-%04" PRIX16 "-%02" PRIX8 "%02" PRIX8 "-%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8,
@@ -412,7 +412,7 @@ HACKY_COM_BEGIN(IA3dSource, 7)
   hacky_printf("a 0x%" PRIX32 "\n", stack[2]);
 
   A3DSOURCE* this = Memory(stack[1]);
-  memcpy(&this->fmt, Memory(stack[2]), sizeof(WAVEFORMATEX));
+  memcpy(&this->fmt, Memory(stack[2]), sizeof(API(WAVEFORMATEX)));
 
   eax = 0;
   esp += 2 * 4;

--- a/com/d3d.c
+++ b/com/d3d.c
@@ -1,3 +1,5 @@
+#include "../emulation.h"
+
 typedef struct {
   uint32_t dwSize;
   uint32_t dwFlags;
@@ -42,7 +44,7 @@ typedef struct {
     uint32_t dwRGBZBitMask;
     uint32_t dwYUVZBitMask;
   } dummy5;
-} DDPIXELFORMAT;
+} API(DDPIXELFORMAT);
 
 #if 0
 

--- a/com/d3d.h
+++ b/com/d3d.h
@@ -1,7 +1,7 @@
 #ifndef __OPENSWE1R_COM_D3D_H__
 #define __OPENSWE1R_COM_D3D_H__
 
-#define DIRECT3D_VERSION 0x0600
+#define API__DIRECT3D_VERSION 0x0600
 
 #include "../emulation.h"
 #include "../windows.h"
@@ -10,7 +10,7 @@ typedef struct {
   void* vtable;
   Address surface;
   GLuint handle;
-} Direct3DTexture2;
+} API(Direct3DTexture2);
 
 typedef struct {
   union {
@@ -29,13 +29,15 @@ typedef struct {
     uint32_t y2;
     uint32_t lY2;
   };
-} D3DRECT;
+} API(D3DRECT);
 
-#define D3DCLEAR_TARGET  0x00000001
-#define D3DCLEAR_ZBUFFER 0x00000002
-#define D3DCLEAR_STENCIL 0x00000004
+enum {
+  API(D3DCLEAR_TARGET) = 0x00000001,
+  API(D3DCLEAR_ZBUFFER) = 0x00000002,
+  API(D3DCLEAR_STENCIL) = 0x00000004
+};
 
-typedef float D3DVALUE; // Assumes 32 bit float
+typedef float API(D3DVALUE); // Assumes 32 bit float
 
 typedef struct {
     uint32_t       dwSize;
@@ -43,68 +45,68 @@ typedef struct {
     uint32_t       dwY;        /* Viewport Top left */
     uint32_t       dwWidth;
     uint32_t       dwHeight;   /* Viewport Dimensions */
-    D3DVALUE    dvClipX;        /* Top left of clip volume */
-    D3DVALUE    dvClipY;
-    D3DVALUE    dvClipWidth;    /* Clip Volume Dimensions */
-    D3DVALUE    dvClipHeight;
-    D3DVALUE    dvMinZ;         /* Min/max of clip Volume */
-    D3DVALUE    dvMaxZ;
-} D3DVIEWPORT2;
+    API(D3DVALUE)    dvClipX;        /* Top left of clip volume */
+    API(D3DVALUE)    dvClipY;
+    API(D3DVALUE)    dvClipWidth;    /* Clip Volume Dimensions */
+    API(D3DVALUE)    dvClipHeight;
+    API(D3DVALUE)    dvMinZ;         /* Min/max of clip Volume */
+    API(D3DVALUE)    dvMaxZ;
+} API(D3DVIEWPORT2);
 
 
 // From DX6 SDK
 
-typedef enum _D3DRENDERSTATETYPE {
-    D3DRENDERSTATE_ANTIALIAS          = 2,    /* D3DANTIALIASMODE */
-    D3DRENDERSTATE_TEXTUREPERSPECTIVE = 4,    /* TRUE for perspective correction */
-    D3DRENDERSTATE_ZENABLE            = 7,    /* D3DZBUFFERTYPE (or TRUE/FALSE for legacy) */
-    D3DRENDERSTATE_FILLMODE           = 8,    /* D3DFILL_MODE        */
-    D3DRENDERSTATE_SHADEMODE          = 9,    /* D3DSHADEMODE */
-    D3DRENDERSTATE_LINEPATTERN        = 10,   /* D3DLINEPATTERN */
-    D3DRENDERSTATE_ZWRITEENABLE       = 14,   /* TRUE to enable z writes */
-    D3DRENDERSTATE_ALPHATESTENABLE    = 15,   /* TRUE to enable alpha tests */
-    D3DRENDERSTATE_LASTPIXEL          = 16,   /* TRUE for last-pixel on lines */
-    D3DRENDERSTATE_SRCBLEND           = 19,   /* D3DBLEND */
-    D3DRENDERSTATE_DESTBLEND          = 20,   /* D3DBLEND */
-    D3DRENDERSTATE_CULLMODE           = 22,   /* D3DCULL */
-    D3DRENDERSTATE_ZFUNC              = 23,   /* D3DCMPFUNC */
-    D3DRENDERSTATE_ALPHAREF           = 24,   /* D3DFIXED */
-    D3DRENDERSTATE_ALPHAFUNC          = 25,   /* D3DCMPFUNC */
-    D3DRENDERSTATE_DITHERENABLE       = 26,   /* TRUE to enable dithering */
-#if(DIRECT3D_VERSION >= 0x0500)
-    D3DRENDERSTATE_ALPHABLENDENABLE   = 27,   /* TRUE to enable alpha blending */
-#endif /* DIRECT3D_VERSION >= 0x0500 */
-    D3DRENDERSTATE_FOGENABLE          = 28,   /* TRUE to enable fog blending */
-    D3DRENDERSTATE_SPECULARENABLE     = 29,   /* TRUE to enable specular */
-    D3DRENDERSTATE_ZVISIBLE           = 30,   /* TRUE to enable z checking */
-    D3DRENDERSTATE_STIPPLEDALPHA      = 33,   /* TRUE to enable stippled alpha (RGB device only) */
-    D3DRENDERSTATE_FOGCOLOR           = 34,   /* D3DCOLOR */
-    D3DRENDERSTATE_FOGTABLEMODE       = 35,   /* D3DFOGMODE */
-#if(DIRECT3D_VERSION >= 0x0700)
-    D3DRENDERSTATE_FOGSTART           = 36,   /* Fog start (for both vertex and pixel fog) */
-    D3DRENDERSTATE_FOGEND             = 37,   /* Fog end      */
-    D3DRENDERSTATE_FOGDENSITY         = 38,   /* Fog density  */
-#endif /* DIRECT3D_VERSION >= 0x0700 */
-#if(DIRECT3D_VERSION >= 0x0500)
-    D3DRENDERSTATE_EDGEANTIALIAS      = 40,   /* TRUE to enable edge antialiasing */
-    D3DRENDERSTATE_COLORKEYENABLE     = 41,   /* TRUE to enable source colorkeyed textures */
-    D3DRENDERSTATE_ZBIAS              = 47,   /* LONG Z bias */
-    D3DRENDERSTATE_RANGEFOGENABLE     = 48,   /* Enables range-based fog */
-#endif /* DIRECT3D_VERSION >= 0x0500 */
+typedef enum {
+    API(D3DRENDERSTATE_ANTIALIAS)         = 2,    /* D3DANTIALIASMODE */
+    API(D3DRENDERSTATE_TEXTUREPERSPECTIVE)= 4,    /* TRUE for perspective correction */
+    API(D3DRENDERSTATE_ZENABLE)           = 7,    /* D3DZBUFFERTYPE (or TRUE/FALSE for legacy) */
+    API(D3DRENDERSTATE_FILLMODE)          = 8,    /* D3DFILL_MODE        */
+    API(D3DRENDERSTATE_SHADEMODE)         = 9,    /* D3DSHADEMODE */
+    API(D3DRENDERSTATE_LINEPATTERN)       = 10,   /* D3DLINEPATTERN */
+    API(D3DRENDERSTATE_ZWRITEENABLE)      = 14,   /* TRUE to enable z writes */
+    API(D3DRENDERSTATE_ALPHATESTENABLE)   = 15,   /* TRUE to enable alpha tests */
+    API(D3DRENDERSTATE_LASTPIXEL)         = 16,   /* TRUE for last-pixel on lines */
+    API(D3DRENDERSTATE_SRCBLEND)          = 19,   /* D3DBLEND */
+    API(D3DRENDERSTATE_DESTBLEND)         = 20,   /* D3DBLEND */
+    API(D3DRENDERSTATE_CULLMODE)          = 22,   /* D3DCULL */
+    API(D3DRENDERSTATE_ZFUNC)             = 23,   /* D3DCMPFUNC */
+    API(D3DRENDERSTATE_ALPHAREF)          = 24,   /* D3DFIXED */
+    API(D3DRENDERSTATE_ALPHAFUNC)         = 25,   /* D3DCMPFUNC */
+    API(D3DRENDERSTATE_DITHERENABLE)      = 26,   /* TRUE to enable dithering */
+#if(API__DIRECT3D_VERSION >= 0x0500)
+    API(D3DRENDERSTATE_ALPHABLENDENABLE)  = 27,   /* TRUE to enable alpha blending */
+#endif /* API__DIRECT3D_VERSION >= 0x0500 */
+    API(D3DRENDERSTATE_FOGENABLE)         = 28,   /* TRUE to enable fog blending */
+    API(D3DRENDERSTATE_SPECULARENABLE)    = 29,   /* TRUE to enable specular */
+    API(D3DRENDERSTATE_ZVISIBLE)          = 30,   /* TRUE to enable z checking */
+    API(D3DRENDERSTATE_STIPPLEDALPHA)     = 33,   /* TRUE to enable stippled alpha (RGB device only) */
+    API(D3DRENDERSTATE_FOGCOLOR)          = 34,   /* D3DCOLOR */
+    API(D3DRENDERSTATE_FOGTABLEMODE)      = 35,   /* D3DFOGMODE */
+#if(API__DIRECT3D_VERSION >= 0x0700)
+    API(D3DRENDERSTATE_FOGSTART)          = 36,   /* Fog start (for both vertex and pixel fog) */
+    API(D3DRENDERSTATE_FOGEND)            = 37,   /* Fog end      */
+    API(D3DRENDERSTATE_FOGDENSITY)        = 38,   /* Fog density  */
+#endif /* API__DIRECT3D_VERSION >= 0x0700 */
+#if(API__DIRECT3D_VERSION >= 0x0500)
+    API(D3DRENDERSTATE_EDGEANTIALIAS)     = 40,   /* TRUE to enable edge antialiasing */
+    API(D3DRENDERSTATE_COLORKEYENABLE)    = 41,   /* TRUE to enable source colorkeyed textures */
+    API(D3DRENDERSTATE_ZBIAS)             = 47,   /* LONG Z bias */
+    API(D3DRENDERSTATE_RANGEFOGENABLE)    = 48,   /* Enables range-based fog */
+#endif /* API__DIRECT3D_VERSION >= 0x0500 */
 
-#if(DIRECT3D_VERSION >= 0x0600)
-    D3DRENDERSTATE_STENCILENABLE      = 52,   /* BOOL enable/disable stenciling */
-    D3DRENDERSTATE_STENCILFAIL        = 53,   /* D3DSTENCILOP to do if stencil test fails */
-    D3DRENDERSTATE_STENCILZFAIL       = 54,   /* D3DSTENCILOP to do if stencil test passes and Z test fails */
-    D3DRENDERSTATE_STENCILPASS        = 55,   /* D3DSTENCILOP to do if both stencil and Z tests pass */
-    D3DRENDERSTATE_STENCILFUNC        = 56,   /* D3DCMPFUNC fn.  Stencil Test passes if ((ref & mask) stencilfn (stencil & mask)) is true */
-    D3DRENDERSTATE_STENCILREF         = 57,   /* Reference value used in stencil test */
-    D3DRENDERSTATE_STENCILMASK        = 58,   /* Mask value used in stencil test */
-    D3DRENDERSTATE_STENCILWRITEMASK   = 59,   /* Write mask applied to values written to stencil buffer */
-    D3DRENDERSTATE_TEXTUREFACTOR      = 60,   /* D3DCOLOR used for multi-texture blend */
-#endif /* DIRECT3D_VERSION >= 0x0600 */
+#if(API__DIRECT3D_VERSION >= 0x0600)
+    API(D3DRENDERSTATE_STENCILENABLE)     = 52,   /* BOOL enable/disable stenciling */
+    API(D3DRENDERSTATE_STENCILFAIL)       = 53,   /* D3DSTENCILOP to do if stencil test fails */
+    API(D3DRENDERSTATE_STENCILZFAIL)      = 54,   /* D3DSTENCILOP to do if stencil test passes and Z test fails */
+    API(D3DRENDERSTATE_STENCILPASS)       = 55,   /* D3DSTENCILOP to do if both stencil and Z tests pass */
+    API(D3DRENDERSTATE_STENCILFUNC)       = 56,   /* D3DCMPFUNC fn.  Stencil Test passes if ((ref & mask) stencilfn (stencil & mask)) is true */
+    API(D3DRENDERSTATE_STENCILREF)        = 57,   /* Reference value used in stencil test */
+    API(D3DRENDERSTATE_STENCILMASK)       = 58,   /* Mask value used in stencil test */
+    API(D3DRENDERSTATE_STENCILWRITEMASK)  = 59,   /* Write mask applied to values written to stencil buffer */
+    API(D3DRENDERSTATE_TEXTUREFACTOR)     = 60,   /* D3DCOLOR used for multi-texture blend */
+#endif /* API__DIRECT3D_VERSION >= 0x0600 */
 
-#if(DIRECT3D_VERSION >= 0x0600)
+#if(API__DIRECT3D_VERSION >= 0x0600)
 
     /*
      * 128 values [128, 255] are reserved for texture coordinate wrap flags.
@@ -112,113 +114,113 @@ typedef enum _D3DRENDERSTATETYPE {
      * a flags uint16_t preserves forward compatibility with texture coordinates
      * that are >2D.
      */
-    D3DRENDERSTATE_WRAP0              = 128,  /* wrap for 1st texture coord. set */
-    D3DRENDERSTATE_WRAP1              = 129,  /* wrap for 2nd texture coord. set */
-    D3DRENDERSTATE_WRAP2              = 130,  /* wrap for 3rd texture coord. set */
-    D3DRENDERSTATE_WRAP3              = 131,  /* wrap for 4th texture coord. set */
-    D3DRENDERSTATE_WRAP4              = 132,  /* wrap for 5th texture coord. set */
-    D3DRENDERSTATE_WRAP5              = 133,  /* wrap for 6th texture coord. set */
-    D3DRENDERSTATE_WRAP6              = 134,  /* wrap for 7th texture coord. set */
-    D3DRENDERSTATE_WRAP7              = 135,  /* wrap for 8th texture coord. set */
-#endif /* DIRECT3D_VERSION >= 0x0600 */
-#if(DIRECT3D_VERSION >= 0x0700)
-    D3DRENDERSTATE_CLIPPING            = 136,
-    D3DRENDERSTATE_LIGHTING            = 137,
-    D3DRENDERSTATE_EXTENTS             = 138,
-    D3DRENDERSTATE_AMBIENT             = 139,
-    D3DRENDERSTATE_FOGVERTEXMODE       = 140,
-    D3DRENDERSTATE_COLORVERTEX         = 141,
-    D3DRENDERSTATE_LOCALVIEWER         = 142,
-    D3DRENDERSTATE_NORMALIZENORMALS    = 143,
-    D3DRENDERSTATE_COLORKEYBLENDENABLE = 144,
-    D3DRENDERSTATE_DIFFUSEMATERIALSOURCE    = 145,
-    D3DRENDERSTATE_SPECULARMATERIALSOURCE   = 146,
-    D3DRENDERSTATE_AMBIENTMATERIALSOURCE    = 147,
-    D3DRENDERSTATE_EMISSIVEMATERIALSOURCE   = 148,
-    D3DRENDERSTATE_VERTEXBLEND              = 151,
-    D3DRENDERSTATE_CLIPPLANEENABLE          = 152,
+    API(D3DRENDERSTATE_WRAP0)             = 128,  /* wrap for 1st texture coord. set */
+    API(D3DRENDERSTATE_WRAP1)             = 129,  /* wrap for 2nd texture coord. set */
+    API(D3DRENDERSTATE_WRAP2)             = 130,  /* wrap for 3rd texture coord. set */
+    API(D3DRENDERSTATE_WRAP3)             = 131,  /* wrap for 4th texture coord. set */
+    API(D3DRENDERSTATE_WRAP4)             = 132,  /* wrap for 5th texture coord. set */
+    API(D3DRENDERSTATE_WRAP5)             = 133,  /* wrap for 6th texture coord. set */
+    API(D3DRENDERSTATE_WRAP6)             = 134,  /* wrap for 7th texture coord. set */
+    API(D3DRENDERSTATE_WRAP7)             = 135,  /* wrap for 8th texture coord. set */
+#endif /* API__DIRECT3D_VERSION >= 0x0600 */
+#if(API__DIRECT3D_VERSION >= 0x0700)
+    API(D3DRENDERSTATE_CLIPPING)           = 136,
+    API(D3DRENDERSTATE_LIGHTING)           = 137,
+    API(D3DRENDERSTATE_EXTENTS)            = 138,
+    API(D3DRENDERSTATE_AMBIENT)            = 139,
+    API(D3DRENDERSTATE_FOGVERTEXMODE)      = 140,
+    API(D3DRENDERSTATE_COLORVERTEX)        = 141,
+    API(D3DRENDERSTATE_LOCALVIEWER)        = 142,
+    API(D3DRENDERSTATE_NORMALIZENORMALS)   = 143,
+    API(D3DRENDERSTATE_COLORKEYBLENDENABLE)     = 144,
+    API(D3DRENDERSTATE_DIFFUSEMATERIALSOURCE)   = 145,
+    API(D3DRENDERSTATE_SPECULARMATERIALSOURCE)  = 146,
+    API(D3DRENDERSTATE_AMBIENTMATERIALSOURCE)   = 147,
+    API(D3DRENDERSTATE_EMISSIVEMATERIALSOURCE)  = 148,
+    API(D3DRENDERSTATE_VERTEXBLEND)             = 151,
+    API(D3DRENDERSTATE_CLIPPLANEENABLE)         = 152,
 
-#endif /* DIRECT3D_VERSION >= 0x0700 */
+#endif /* API__DIRECT3D_VERSION >= 0x0700 */
 
 //
 // retired renderstates - not supported for DX7 interfaces
 //
-    D3DRENDERSTATE_TEXTUREHANDLE      = 1,    /* Texture handle for legacy interfaces (Texture,Texture2) */
-    D3DRENDERSTATE_TEXTUREADDRESS     = 3,    /* D3DTEXTUREADDRESS  */
-    D3DRENDERSTATE_WRAPU              = 5,    /* TRUE for wrapping in u */
-    D3DRENDERSTATE_WRAPV              = 6,    /* TRUE for wrapping in v */
-    D3DRENDERSTATE_MONOENABLE         = 11,   /* TRUE to enable mono rasterization */
-    D3DRENDERSTATE_ROP2               = 12,   /* ROP2 */
-    D3DRENDERSTATE_PLANEMASK          = 13,   /* uint32_t physical plane mask */
-    D3DRENDERSTATE_TEXTUREMAG         = 17,   /* D3DTEXTUREFILTER */
-    D3DRENDERSTATE_TEXTUREMIN         = 18,   /* D3DTEXTUREFILTER */
-    D3DRENDERSTATE_TEXTUREMAPBLEND    = 21,   /* D3DTEXTUREBLEND */
-    D3DRENDERSTATE_SUBPIXEL           = 31,   /* TRUE to enable subpixel correction */
-    D3DRENDERSTATE_SUBPIXELX          = 32,   /* TRUE to enable correction in X only */
-    D3DRENDERSTATE_STIPPLEENABLE      = 39,   /* TRUE to enable stippling */
-#if(DIRECT3D_VERSION >= 0x0500)
-    D3DRENDERSTATE_BORDERCOLOR        = 43,   /* Border color for texturing w/border */
-    D3DRENDERSTATE_TEXTUREADDRESSU    = 44,   /* Texture addressing mode for U coordinate */
-    D3DRENDERSTATE_TEXTUREADDRESSV    = 45,   /* Texture addressing mode for V coordinate */
-    D3DRENDERSTATE_MIPMAPLODBIAS      = 46,   /* D3DVALUE Mipmap LOD bias */
-    D3DRENDERSTATE_ANISOTROPY         = 49,   /* Max. anisotropy. 1 = no anisotropy */
-#endif /* DIRECT3D_VERSION >= 0x0500 */
-    D3DRENDERSTATE_FLUSHBATCH         = 50,   /* Explicit flush for DP batching (DX5 Only) */
-#if(DIRECT3D_VERSION >= 0x0600)
-    D3DRENDERSTATE_TRANSLUCENTSORTINDEPENDENT=51, /* BOOL enable sort-independent transparency */
-#endif /* DIRECT3D_VERSION >= 0x0600 */
-    D3DRENDERSTATE_STIPPLEPATTERN00   = 64,   /* Stipple pattern 01...  */
-    D3DRENDERSTATE_STIPPLEPATTERN01   = 65,
-    D3DRENDERSTATE_STIPPLEPATTERN02   = 66,
-    D3DRENDERSTATE_STIPPLEPATTERN03   = 67,
-    D3DRENDERSTATE_STIPPLEPATTERN04   = 68,
-    D3DRENDERSTATE_STIPPLEPATTERN05   = 69,
-    D3DRENDERSTATE_STIPPLEPATTERN06   = 70,
-    D3DRENDERSTATE_STIPPLEPATTERN07   = 71,
-    D3DRENDERSTATE_STIPPLEPATTERN08   = 72,
-    D3DRENDERSTATE_STIPPLEPATTERN09   = 73,
-    D3DRENDERSTATE_STIPPLEPATTERN10   = 74,
-    D3DRENDERSTATE_STIPPLEPATTERN11   = 75,
-    D3DRENDERSTATE_STIPPLEPATTERN12   = 76,
-    D3DRENDERSTATE_STIPPLEPATTERN13   = 77,
-    D3DRENDERSTATE_STIPPLEPATTERN14   = 78,
-    D3DRENDERSTATE_STIPPLEPATTERN15   = 79,
-    D3DRENDERSTATE_STIPPLEPATTERN16   = 80,
-    D3DRENDERSTATE_STIPPLEPATTERN17   = 81,
-    D3DRENDERSTATE_STIPPLEPATTERN18   = 82,
-    D3DRENDERSTATE_STIPPLEPATTERN19   = 83,
-    D3DRENDERSTATE_STIPPLEPATTERN20   = 84,
-    D3DRENDERSTATE_STIPPLEPATTERN21   = 85,
-    D3DRENDERSTATE_STIPPLEPATTERN22   = 86,
-    D3DRENDERSTATE_STIPPLEPATTERN23   = 87,
-    D3DRENDERSTATE_STIPPLEPATTERN24   = 88,
-    D3DRENDERSTATE_STIPPLEPATTERN25   = 89,
-    D3DRENDERSTATE_STIPPLEPATTERN26   = 90,
-    D3DRENDERSTATE_STIPPLEPATTERN27   = 91,
-    D3DRENDERSTATE_STIPPLEPATTERN28   = 92,
-    D3DRENDERSTATE_STIPPLEPATTERN29   = 93,
-    D3DRENDERSTATE_STIPPLEPATTERN30   = 94,
-    D3DRENDERSTATE_STIPPLEPATTERN31   = 95,
+    API(D3DRENDERSTATE_TEXTUREHANDLE)     = 1,    /* Texture handle for legacy interfaces (Texture,Texture2) */
+    API(D3DRENDERSTATE_TEXTUREADDRESS)    = 3,    /* D3DTEXTUREADDRESS  */
+    API(D3DRENDERSTATE_WRAPU)             = 5,    /* TRUE for wrapping in u */
+    API(D3DRENDERSTATE_WRAPV)             = 6,    /* TRUE for wrapping in v */
+    API(D3DRENDERSTATE_MONOENABLE)        = 11,   /* TRUE to enable mono rasterization */
+    API(D3DRENDERSTATE_ROP2)              = 12,   /* ROP2 */
+    API(D3DRENDERSTATE_PLANEMASK)         = 13,   /* uint32_t physical plane mask */
+    API(D3DRENDERSTATE_TEXTUREMAG)        = 17,   /* D3DTEXTUREFILTER */
+    API(D3DRENDERSTATE_TEXTUREMIN)        = 18,   /* D3DTEXTUREFILTER */
+    API(D3DRENDERSTATE_TEXTUREMAPBLEND)   = 21,   /* D3DTEXTUREBLEND */
+    API(D3DRENDERSTATE_SUBPIXEL)          = 31,   /* TRUE to enable subpixel correction */
+    API(D3DRENDERSTATE_SUBPIXELX)         = 32,   /* TRUE to enable correction in X only */
+    API(D3DRENDERSTATE_STIPPLEENABLE)     = 39,   /* TRUE to enable stippling */
+#if(API__DIRECT3D_VERSION >= 0x0500)
+    API(D3DRENDERSTATE_BORDERCOLOR)       = 43,   /* Border color for texturing w/border */
+    API(D3DRENDERSTATE_TEXTUREADDRESSU)   = 44,   /* Texture addressing mode for U coordinate */
+    API(D3DRENDERSTATE_TEXTUREADDRESSV)   = 45,   /* Texture addressing mode for V coordinate */
+    API(D3DRENDERSTATE_MIPMAPLODBIAS)     = 46,   /* D3DVALUE Mipmap LOD bias */
+    API(D3DRENDERSTATE_ANISOTROPY)        = 49,   /* Max. anisotropy. 1 = no anisotropy */
+#endif /* API__DIRECT3D_VERSION >= 0x0500 */
+    API(D3DRENDERSTATE_FLUSHBATCH)        = 50,   /* Explicit flush for DP batching (DX5 Only) */
+#if(API__DIRECT3D_VERSION >= 0x0600)
+    API(D3DRENDERSTATE_TRANSLUCENTSORTINDEPENDENT)=51, /* BOOL enable sort-independent transparency */
+#endif /* API__DIRECT3D_VERSION >= 0x0600 */
+    API(D3DRENDERSTATE_STIPPLEPATTERN00)  = 64,   /* Stipple pattern 01...  */
+    API(D3DRENDERSTATE_STIPPLEPATTERN01)  = 65,
+    API(D3DRENDERSTATE_STIPPLEPATTERN02)  = 66,
+    API(D3DRENDERSTATE_STIPPLEPATTERN03)  = 67,
+    API(D3DRENDERSTATE_STIPPLEPATTERN04)  = 68,
+    API(D3DRENDERSTATE_STIPPLEPATTERN05)  = 69,
+    API(D3DRENDERSTATE_STIPPLEPATTERN06)  = 70,
+    API(D3DRENDERSTATE_STIPPLEPATTERN07)  = 71,
+    API(D3DRENDERSTATE_STIPPLEPATTERN08)  = 72,
+    API(D3DRENDERSTATE_STIPPLEPATTERN09)  = 73,
+    API(D3DRENDERSTATE_STIPPLEPATTERN10)  = 74,
+    API(D3DRENDERSTATE_STIPPLEPATTERN11)  = 75,
+    API(D3DRENDERSTATE_STIPPLEPATTERN12)  = 76,
+    API(D3DRENDERSTATE_STIPPLEPATTERN13)  = 77,
+    API(D3DRENDERSTATE_STIPPLEPATTERN14)  = 78,
+    API(D3DRENDERSTATE_STIPPLEPATTERN15)  = 79,
+    API(D3DRENDERSTATE_STIPPLEPATTERN16)  = 80,
+    API(D3DRENDERSTATE_STIPPLEPATTERN17)  = 81,
+    API(D3DRENDERSTATE_STIPPLEPATTERN18)  = 82,
+    API(D3DRENDERSTATE_STIPPLEPATTERN19)  = 83,
+    API(D3DRENDERSTATE_STIPPLEPATTERN20)  = 84,
+    API(D3DRENDERSTATE_STIPPLEPATTERN21)  = 85,
+    API(D3DRENDERSTATE_STIPPLEPATTERN22)  = 86,
+    API(D3DRENDERSTATE_STIPPLEPATTERN23)  = 87,
+    API(D3DRENDERSTATE_STIPPLEPATTERN24)  = 88,
+    API(D3DRENDERSTATE_STIPPLEPATTERN25)  = 89,
+    API(D3DRENDERSTATE_STIPPLEPATTERN26)  = 90,
+    API(D3DRENDERSTATE_STIPPLEPATTERN27)  = 91,
+    API(D3DRENDERSTATE_STIPPLEPATTERN28)  = 92,
+    API(D3DRENDERSTATE_STIPPLEPATTERN29)  = 93,
+    API(D3DRENDERSTATE_STIPPLEPATTERN30)  = 94,
+    API(D3DRENDERSTATE_STIPPLEPATTERN31)  = 95,
 
 //
 // retired renderstate names - the values are still used under new naming conventions
 //
-    D3DRENDERSTATE_FOGTABLESTART      = 36,   /* Fog table start    */
-    D3DRENDERSTATE_FOGTABLEEND        = 37,   /* Fog table end      */
-    D3DRENDERSTATE_FOGTABLEDENSITY    = 38,   /* Fog table density  */
+    API(D3DRENDERSTATE_FOGTABLESTART)     = 36,   /* Fog table start    */
+    API(D3DRENDERSTATE_FOGTABLEEND)       = 37,   /* Fog table end      */
+    API(D3DRENDERSTATE_FOGTABLEDENSITY)   = 38,   /* Fog table density  */
 
-#if(DIRECT3D_VERSION >= 0x0500)
-    D3DRENDERSTATE_FORCE_uint32_t        = 0x7fffffff, /* force 32-bit size enum */
-#endif /* DIRECT3D_VERSION >= 0x0500 */
-} D3DRENDERSTATETYPE;
-
-
+#if(API__DIRECT3D_VERSION >= 0x0500)
+    API(D3DRENDERSTATE_FORCE_DWORD)       = 0x7fffffff, /* force 32-bit size enum */
+#endif /* API__DIRECT3D_VERSION >= 0x0500 */
+} API(D3DRENDERSTATETYPE);
 
 
 
 
 
-typedef uint32_t D3DCOLORMODEL;
+
+
+typedef uint32_t API(D3DCOLORMODEL);
 
 
 typedef struct {
@@ -236,35 +238,35 @@ typedef struct {
     uint32_t dwTextureAddressCaps;
     uint32_t dwStippleWidth;             /* maximum width and height of */
     uint32_t dwStippleHeight;            /* of supported stipple (up to 32x32) */
-} D3DPRIMCAPS;
+} API(D3DPRIMCAPS);
 
 typedef struct {
     uint32_t dwSize;
     uint32_t dwCaps;                   /* Lighting caps */
     uint32_t dwLightingModel;          /* Lighting model - RGB or mono */
     uint32_t dwNumLights;              /* Number of lights that can be handled */
-} D3DLIGHTINGCAPS;
+} API(D3DLIGHTINGCAPS);
 
 typedef struct {
     uint32_t dwSize;
     uint32_t dwCaps;
-} D3DTRANSFORMCAPS;
+} API(D3DTRANSFORMCAPS);
 
 typedef struct {
-    uint32_t            dwSize;                 /* Size of D3DDEVICEDESC structure */
-    uint32_t            dwFlags;                /* Indicates which fields have valid data */
-    D3DCOLORMODEL    dcmColorModel;          /* Color model of device */
-    uint32_t            dwDevCaps;              /* Capabilities of device */
-    D3DTRANSFORMCAPS dtcTransformCaps;       /* Capabilities of transform */
-    uint8_t             bClipping;              /* Device can do 3D clipping */
-    D3DLIGHTINGCAPS  dlcLightingCaps;        /* Capabilities of lighting */
-    D3DPRIMCAPS      dpcLineCaps;
-    D3DPRIMCAPS      dpcTriCaps;
-    uint32_t            dwDeviceRenderBitDepth; /* One of DDBB_8, 16, etc.. */
-    uint32_t            dwDeviceZBufferBitDepth;/* One of DDBD_16, 32, etc.. */
-    uint32_t            dwMaxBufferSize;        /* Maximum execute buffer size */
-    uint32_t            dwMaxVertexCount;       /* Maximum vertex count */
-#if(DIRECT3D_VERSION >= 0x0500)
+    uint32_t             dwSize;                 /* Size of D3DDEVICEDESC structure */
+    uint32_t             dwFlags;                /* Indicates which fields have valid data */
+    API(D3DCOLORMODEL)    dcmColorModel;          /* Color model of device */
+    uint32_t             dwDevCaps;              /* Capabilities of device */
+    API(D3DTRANSFORMCAPS) dtcTransformCaps;       /* Capabilities of transform */
+    uint8_t              bClipping;              /* Device can do 3D clipping */
+    API(D3DLIGHTINGCAPS)  dlcLightingCaps;        /* Capabilities of lighting */
+    API(D3DPRIMCAPS)      dpcLineCaps;
+    API(D3DPRIMCAPS)      dpcTriCaps;
+    uint32_t             dwDeviceRenderBitDepth; /* One of DDBB_8, 16, etc.. */
+    uint32_t             dwDeviceZBufferBitDepth;/* One of DDBD_16, 32, etc.. */
+    uint32_t             dwMaxBufferSize;        /* Maximum execute buffer size */
+    uint32_t             dwMaxVertexCount;       /* Maximum vertex count */
+#if(API__DIRECT3D_VERSION >= 0x0500)
     // *** New fields for DX5 *** //
 
     // Width and height caps are 0 for legacy HALs.
@@ -272,75 +274,50 @@ typedef struct {
     uint32_t        dwMaxTextureWidth, dwMaxTextureHeight;
     uint32_t        dwMinStippleWidth, dwMaxStippleWidth;
     uint32_t        dwMinStippleHeight, dwMaxStippleHeight;
-#endif /* DIRECT3D_VERSION >= 0x0500 */
+#endif /* API__DIRECT3D_VERSION >= 0x0500 */
 
-#if(DIRECT3D_VERSION >= 0x0600)
+#if(API__DIRECT3D_VERSION >= 0x0600)
     // New fields for DX6
-    uint32_t       dwMaxTextureRepeat;
-    uint32_t       dwMaxTextureAspectRatio;
-    uint32_t       dwMaxAnisotropy;
+    uint32_t        dwMaxTextureRepeat;
+    uint32_t        dwMaxTextureAspectRatio;
+    uint32_t        dwMaxAnisotropy;
 
     // Guard band that the rasterizer can accommodate
     // Screen-space vertices inside this space but outside the viewport
     // will get clipped properly.
-    D3DVALUE    dvGuardBandLeft;
-    D3DVALUE    dvGuardBandTop;
-    D3DVALUE    dvGuardBandRight;
-    D3DVALUE    dvGuardBandBottom;
+    API(D3DVALUE)    dvGuardBandLeft;
+    API(D3DVALUE)    dvGuardBandTop;
+    API(D3DVALUE)    dvGuardBandRight;
+    API(D3DVALUE)    dvGuardBandBottom;
 
-    D3DVALUE    dvExtentsAdjust;
-    uint32_t       dwStencilCaps;
+    API(D3DVALUE)    dvExtentsAdjust;
+    uint32_t        dwStencilCaps;
 
-    uint32_t       dwFVFCaps;
-    uint32_t       dwTextureOpCaps;
+    uint32_t        dwFVFCaps;
+    uint32_t        dwTextureOpCaps;
     uint16_t        wMaxTextureBlendStages;
     uint16_t        wMaxSimultaneousTextures;
-#endif /* DIRECT3D_VERSION >= 0x0600 */
-} D3DDEVICEDESC;
+#endif /* API__DIRECT3D_VERSION >= 0x0600 */
+} API(D3DDEVICEDESC);
 
 typedef enum { 
-  D3DBLEND_ZERO             = 1,
-  D3DBLEND_ONE              = 2,
-  D3DBLEND_SRCCOLOR         = 3,
-  D3DBLEND_INVSRCCOLOR      = 4,
-  D3DBLEND_SRCALPHA         = 5,
-  D3DBLEND_INVSRCALPHA      = 6,
-  D3DBLEND_DESTALPHA        = 7,
-  D3DBLEND_INVDESTALPHA     = 8,
-  D3DBLEND_DESTCOLOR        = 9,
-  D3DBLEND_INVDESTCOLOR     = 10,
-  D3DBLEND_SRCALPHASAT      = 11,
-  D3DBLEND_BOTHSRCALPHA     = 12,
-  D3DBLEND_BOTHINVSRCALPHA  = 13,
-  D3DBLEND_BLENDFACTOR      = 14,
-  D3DBLEND_INVBLENDFACTOR   = 15,
-  D3DBLEND_SRCCOLOR2        = 16,
-  D3DBLEND_INVSRCCOLOR2     = 17
-} D3DBLEND;
-
-enum {
-    D3DRS_ZENABLE                   = 7,    /* D3DZBUFFERTYPE (or TRUE/FALSE for legacy) */
-    D3DRS_FILLMODE                  = 8,    /* D3DFILLMODE */
-    D3DRS_SHADEMODE                 = 9,    /* D3DSHADEMODE */
-    D3DRS_LINEPATTERN               = 10,   /* D3DLINEPATTERN */
-    D3DRS_ZWRITEENABLE              = 14,   /* TRUE to enable z writes */
-    D3DRS_ALPHATESTENABLE           = 15,   /* TRUE to enable alpha tests */
-    D3DRS_LASTPIXEL                 = 16,   /* TRUE for last-pixel on lines */
-    D3DRS_SRCBLEND                  = 19,   /* D3DBLEND */
-    D3DRS_DESTBLEND                 = 20,   /* D3DBLEND */
-    D3DRS_CULLMODE                  = 22,   /* D3DCULL */
-    D3DRS_ZFUNC                     = 23,   /* D3DCMPFUNC */
-    D3DRS_ALPHAREF                  = 24,   /* D3DFIXED */
-    D3DRS_ALPHAFUNC                 = 25,   /* D3DCMPFUNC */
-    D3DRS_DITHERENABLE              = 26,   /* TRUE to enable dithering */
-    D3DRS_ALPHABLENDENABLE          = 27,   /* TRUE to enable alpha blending */
-    D3DRS_FOGENABLE                 = 28,   /* TRUE to enable fog blending */
-    D3DRS_SPECULARENABLE            = 29,   /* TRUE to enable specular */
-    D3DRS_ZVISIBLE                  = 30,   /* TRUE to enable z checking */
-    D3DRS_FOGCOLOR                  = 34,   /* D3DCOLOR */
-    D3DRS_FOGTABLEMODE              = 35,   /* D3DFOGMODE */
-    D3DRS_FOGSTART                  = 36,   /* Fog start (for both vertex and pixel fog) */
-    D3DRS_FOGEND = 37, /* Fog end      */
-};
+  API(D3DBLEND_ZERO)             = 1,
+  API(D3DBLEND_ONE)              = 2,
+  API(D3DBLEND_SRCCOLOR)         = 3,
+  API(D3DBLEND_INVSRCCOLOR)      = 4,
+  API(D3DBLEND_SRCALPHA)         = 5,
+  API(D3DBLEND_INVSRCALPHA)      = 6,
+  API(D3DBLEND_DESTALPHA)        = 7,
+  API(D3DBLEND_INVDESTALPHA)     = 8,
+  API(D3DBLEND_DESTCOLOR)        = 9,
+  API(D3DBLEND_INVDESTCOLOR)     = 10,
+  API(D3DBLEND_SRCALPHASAT)      = 11,
+  API(D3DBLEND_BOTHSRCALPHA)     = 12,
+  API(D3DBLEND_BOTHINVSRCALPHA)  = 13,
+  API(D3DBLEND_BLENDFACTOR)      = 14,
+  API(D3DBLEND_INVBLENDFACTOR)   = 15,
+  API(D3DBLEND_SRCCOLOR2)        = 16,
+  API(D3DBLEND_INVSRCCOLOR2)     = 17
+} API(D3DBLEND);
 
 #endif

--- a/com/ddraw.h
+++ b/com/ddraw.h
@@ -49,12 +49,12 @@ typedef struct {
     uint32_t dwRGBZBitMask;
     uint32_t dwYUVZBitMask;
   };
-} DDPIXELFORMAT;
+} API(DDPIXELFORMAT);
 
 
 typedef struct {
   uint32_t dwCaps;
-} DDSCAPS;
+} API(DDSCAPS);
 
 
 typedef struct {
@@ -65,9 +65,9 @@ typedef struct {
     uint32_t dwCaps4;
     uint32_t dwVolumeDepth;
   };
-} DDSCAPS2;
+} API(DDSCAPS2);
 
-#define DD_ROP_SPACE (256/32) // space required to store ROP array
+#define API__DD_ROP_SPACE (256/32) // space required to store ROP array
 
 typedef struct {
   uint32_t    dwSize;
@@ -95,8 +95,8 @@ typedef struct {
   uint32_t    dwAlignBoundaryDest;
   uint32_t    dwAlignSizeDest;
   uint32_t    dwAlignStrideAlign;
-  uint32_t    dwRops[DD_ROP_SPACE];
-  DDSCAPS  ddsOldCaps;
+  uint32_t    dwRops[API(DD_ROP_SPACE)];
+  API(DDSCAPS) ddsOldCaps;
   uint32_t    dwMinOverlayStretch;
   uint32_t    dwMaxOverlayStretch;
   uint32_t    dwMinLiveVideoStretch;
@@ -109,15 +109,15 @@ typedef struct {
   uint32_t    dwSVBCaps;
   uint32_t    dwSVBCKeyCaps;
   uint32_t    dwSVBFXCaps;
-  uint32_t    dwSVBRops[DD_ROP_SPACE];
+  uint32_t    dwSVBRops[API(DD_ROP_SPACE)];
   uint32_t    dwVSBCaps;
   uint32_t    dwVSBCKeyCaps;
   uint32_t    dwVSBFXCaps;
-  uint32_t    dwVSBRops[DD_ROP_SPACE];
+  uint32_t    dwVSBRops[API(DD_ROP_SPACE)];
   uint32_t    dwSSBCaps;
   uint32_t    dwSSBCKeyCaps;
   uint32_t    dwSSBFXCaps;
-  uint32_t    dwSSBRops[DD_ROP_SPACE];
+  uint32_t    dwSSBRops[API(DD_ROP_SPACE)];
   uint32_t    dwMaxVideoPorts;
   uint32_t    dwCurrVideoPorts;
   uint32_t    dwSVBCaps2;
@@ -125,17 +125,17 @@ typedef struct {
   uint32_t    dwNLVBCaps2;
   uint32_t    dwNLVBCKeyCaps;
   uint32_t    dwNLVBFXCaps;
-  uint32_t    dwNLVBRops[DD_ROP_SPACE];
-  DDSCAPS2 ddsCaps;
-} DDCAPS;
+  uint32_t    dwNLVBRops[API(DD_ROP_SPACE)];
+  API(DDSCAPS2) ddsCaps;
+} API(DDCAPS);
 
-#define DDSCAPS_TEXTURE 0x00001000
-#define DDSCAPS_MIPMAP  0x00400000
+#define API__DDSCAPS_TEXTURE 0x00001000
+#define API__DDSCAPS_MIPMAP  0x00400000
 
 typedef struct {
   uint32_t dw1;
   uint32_t dw2;
-} DDCOLORKEY;
+} API(DDCOLORKEY);
 
 typedef struct {
   uint32_t      dwSize;
@@ -159,27 +159,29 @@ typedef struct {
   uint32_t      dwReserved;
   Address     lpSurface;
   union {
-    DDCOLORKEY ddckCKDestOverlay;
+    API(DDCOLORKEY) ddckCKDestOverlay;
     uint32_t      dwEmptyFaceColor;
   };
-  DDCOLORKEY ddckCKDestBlt;
-  DDCOLORKEY ddckCKSrcOverlay;
-  DDCOLORKEY ddckCKSrcBlt;
+  API(DDCOLORKEY) ddckCKDestBlt;
+  API(DDCOLORKEY) ddckCKSrcOverlay;
+  API(DDCOLORKEY) ddckCKSrcBlt;
   union {
-    DDPIXELFORMAT ddpfPixelFormat;
+    API(DDPIXELFORMAT) ddpfPixelFormat;
     uint32_t         dwFVF;
   };
-  DDSCAPS2   ddsCaps;
+  API(DDSCAPS2)   ddsCaps;
   uint32_t      dwTextureStage;
-} DDSURFACEDESC2;
+} API(DDSURFACEDESC2);
 
-#define DDPF_ALPHAPIXELS 0x00000001
-#define DDPF_RGB         0x00000040
+enum {
+  API(DDPF_ALPHAPIXELS) = 0x00000001,
+  API(DDPF_RGB) =         0x00000040
+};
 
 typedef struct {
   void* vtable;
   Address texture; // Direct3DTexture2*
-  DDSURFACEDESC2 desc;
-} DirectDrawSurface4;
+  API(DDSURFACEDESC2) desc;
+} API(DirectDrawSurface4);
 
 #endif

--- a/com/dinput.h
+++ b/com/dinput.h
@@ -1,7 +1,7 @@
 #ifndef __OPENSWE1R_COM_DINPUT_H__
 #define __OPENSWE1R_COM_DINPUT_H__
 
-#define DIRECTINPUT_VERSION 0x0600
+#define API__DIRECTINPUT_VERSION 0x0600
 
 #include "../windows.h"
 
@@ -9,218 +9,220 @@
 #include "../emulation.h"
 
 typedef struct {
-  const GUID *pguid;
-  DWORD   dwOfs;
-  DWORD   dwType;
-  DWORD   dwFlags;
-} DIOBJECTDATAFORMAT;
-typedef Address LPDIOBJECTDATAFORMAT;
+  const API(GUID) *pguid;
+  API(DWORD)   dwOfs;
+  API(DWORD)   dwType;
+  API(DWORD)   dwFlags;
+} API(DIOBJECTDATAFORMAT);
+typedef Address API(LPDIOBJECTDATAFORMAT);
 
 typedef struct {
-  DWORD   dwSize;
-  DWORD   dwObjSize;
-  DWORD   dwFlags;
-  DWORD   dwDataSize;
-  DWORD   dwNumObjs;
-  LPDIOBJECTDATAFORMAT rgodf;
-} DIDATAFORMAT;
+  API(DWORD)   dwSize;
+  API(DWORD)   dwObjSize;
+  API(DWORD)   dwFlags;
+  API(DWORD)   dwDataSize;
+  API(DWORD)   dwNumObjs;
+  API(LPDIOBJECTDATAFORMAT) rgodf;
+} API(DIDATAFORMAT);
 
 typedef struct {
-    DWORD   dwSize;
-    GUID    guidInstance;
-    GUID    guidProduct;
-    DWORD   dwDevType;
-    char    tszInstanceName[MAX_PATH];
-    char    tszProductName[MAX_PATH];
-#if (DIRECTINPUT_VERSION >= 0x0500)
-    GUID    guidFFDriver;
+    API(DWORD)   dwSize;
+    API(GUID)    guidInstance;
+    API(GUID)    guidProduct;
+    API(DWORD)   dwDevType;
+    char    tszInstanceName[API(MAX_PATH)];
+    char    tszProductName[API(MAX_PATH)];
+#if (API__DIRECTINPUT_VERSION >= 0x0500)
+    API(GUID)    guidFFDriver;
     uint16_t    wUsagePage;
     uint16_t    wUsage;
 #endif
-} DIDEVICEINSTANCEA;
+} API(DIDEVICEINSTANCEA);
 
 typedef struct {
-    DWORD       dwOfs;
-    DWORD       dwData;
-    DWORD       dwTimeStamp;
-    DWORD       dwSequence;
-#if (DIRECTINPUT_VERSION >= 0x0800)
-    UINT_PTR    uAppData;
+    API(DWORD)       dwOfs;
+    API(DWORD)       dwData;
+    API(DWORD)       dwTimeStamp;
+    API(DWORD)       dwSequence;
+#if (API__DIRECTINPUT_VERSION >= 0x0800)
+    API(UINT_PTR)    uAppData;
 #endif
-} DIDEVICEOBJECTDATA;
+} API(DIDEVICEOBJECTDATA);
 
 
 // From Microsoft DX6 SDK headers
 
-#define DIK_ESCAPE          0x01
-#define DIK_1               0x02
-#define DIK_2               0x03
-#define DIK_3               0x04
-#define DIK_4               0x05
-#define DIK_5               0x06
-#define DIK_6               0x07
-#define DIK_7               0x08
-#define DIK_8               0x09
-#define DIK_9               0x0A
-#define DIK_0               0x0B
-#define DIK_MINUS           0x0C    /* - on main keyboard */
-#define DIK_EQUALS          0x0D
-#define DIK_BACK            0x0E    /* backspace */
-#define DIK_TAB             0x0F
-#define DIK_Q               0x10
-#define DIK_W               0x11
-#define DIK_E               0x12
-#define DIK_R               0x13
-#define DIK_T               0x14
-#define DIK_Y               0x15
-#define DIK_U               0x16
-#define DIK_I               0x17
-#define DIK_O               0x18
-#define DIK_P               0x19
-#define DIK_LBRACKET        0x1A
-#define DIK_RBRACKET        0x1B
-#define DIK_RETURN          0x1C    /* Enter on main keyboard */
-#define DIK_LCONTROL        0x1D
-#define DIK_A               0x1E
-#define DIK_S               0x1F
-#define DIK_D               0x20
-#define DIK_F               0x21
-#define DIK_G               0x22
-#define DIK_H               0x23
-#define DIK_J               0x24
-#define DIK_K               0x25
-#define DIK_L               0x26
-#define DIK_SEMICOLON       0x27
-#define DIK_APOSTROPHE      0x28
-#define DIK_GRAVE           0x29    /* accent grave */
-#define DIK_LSHIFT          0x2A
-#define DIK_BACKSLASH       0x2B
-#define DIK_Z               0x2C
-#define DIK_X               0x2D
-#define DIK_C               0x2E
-#define DIK_V               0x2F
-#define DIK_B               0x30
-#define DIK_N               0x31
-#define DIK_M               0x32
-#define DIK_COMMA           0x33
-#define DIK_PERIOD          0x34    /* . on main keyboard */
-#define DIK_SLASH           0x35    /* / on main keyboard */
-#define DIK_RSHIFT          0x36
-#define DIK_MULTIPLY        0x37    /* * on numeric keypad */
-#define DIK_LMENU           0x38    /* left Alt */
-#define DIK_SPACE           0x39
-#define DIK_CAPITAL         0x3A
-#define DIK_F1              0x3B
-#define DIK_F2              0x3C
-#define DIK_F3              0x3D
-#define DIK_F4              0x3E
-#define DIK_F5              0x3F
-#define DIK_F6              0x40
-#define DIK_F7              0x41
-#define DIK_F8              0x42
-#define DIK_F9              0x43
-#define DIK_F10             0x44
-#define DIK_NUMLOCK         0x45
-#define DIK_SCROLL          0x46    /* Scroll Lock */
-#define DIK_NUMPAD7         0x47
-#define DIK_NUMPAD8         0x48
-#define DIK_NUMPAD9         0x49
-#define DIK_SUBTRACT        0x4A    /* - on numeric keypad */
-#define DIK_NUMPAD4         0x4B
-#define DIK_NUMPAD5         0x4C
-#define DIK_NUMPAD6         0x4D
-#define DIK_ADD             0x4E    /* + on numeric keypad */
-#define DIK_NUMPAD1         0x4F
-#define DIK_NUMPAD2         0x50
-#define DIK_NUMPAD3         0x51
-#define DIK_NUMPAD0         0x52
-#define DIK_DECIMAL         0x53    /* . on numeric keypad */
-#define DIK_OEM_102         0x56    /* < > | on UK/Germany keyboards */
-#define DIK_F11             0x57
-#define DIK_F12             0x58
+enum {
+  API(DIK_ESCAPE) =          0x01,
+  API(DIK_1) =               0x02,
+  API(DIK_2) =               0x03,
+  API(DIK_3) =               0x04,
+  API(DIK_4) =               0x05,
+  API(DIK_5) =               0x06,
+  API(DIK_6) =               0x07,
+  API(DIK_7) =               0x08,
+  API(DIK_8) =               0x09,
+  API(DIK_9) =               0x0A,
+  API(DIK_0) =               0x0B,
+  API(DIK_MINUS) =           0x0C,    /* - on main keyboard */
+  API(DIK_EQUALS) =          0x0D,
+  API(DIK_BACK) =            0x0E,    /* backspace */
+  API(DIK_TAB) =             0x0F,
+  API(DIK_Q) =               0x10,
+  API(DIK_W) =               0x11,
+  API(DIK_E) =               0x12,
+  API(DIK_R) =               0x13,
+  API(DIK_T) =               0x14,
+  API(DIK_Y) =               0x15,
+  API(DIK_U) =               0x16,
+  API(DIK_I) =               0x17,
+  API(DIK_O) =               0x18,
+  API(DIK_P) =               0x19,
+  API(DIK_LBRACKET) =        0x1A,
+  API(DIK_RBRACKET) =        0x1B,
+  API(DIK_RETURN) =          0x1C,    /* Enter on main keyboard */
+  API(DIK_LCONTROL) =        0x1D,
+  API(DIK_A) =               0x1E,
+  API(DIK_S) =               0x1F,
+  API(DIK_D) =               0x20,
+  API(DIK_F) =               0x21,
+  API(DIK_G) =               0x22,
+  API(DIK_H) =               0x23,
+  API(DIK_J) =               0x24,
+  API(DIK_K) =               0x25,
+  API(DIK_L) =               0x26,
+  API(DIK_SEMICOLON) =       0x27,
+  API(DIK_APOSTROPHE) =      0x28,
+  API(DIK_GRAVE) =           0x29,    /* accent grave */
+  API(DIK_LSHIFT) =          0x2A,
+  API(DIK_BACKSLASH) =       0x2B,
+  API(DIK_Z) =               0x2C,
+  API(DIK_X) =               0x2D,
+  API(DIK_C) =               0x2E,
+  API(DIK_V) =               0x2F,
+  API(DIK_B) =               0x30,
+  API(DIK_N) =               0x31,
+  API(DIK_M) =               0x32,
+  API(DIK_COMMA) =           0x33,
+  API(DIK_PERIOD) =          0x34,    /* . on main keyboard */
+  API(DIK_SLASH) =           0x35,    /* / on main keyboard */
+  API(DIK_RSHIFT) =          0x36,
+  API(DIK_MULTIPLY) =        0x37,    /* * on numeric keypad */
+  API(DIK_LMENU) =           0x38,    /* left Alt */
+  API(DIK_SPACE) =           0x39,
+  API(DIK_CAPITAL) =         0x3A,
+  API(DIK_F1) =              0x3B,
+  API(DIK_F2) =              0x3C,
+  API(DIK_F3) =              0x3D,
+  API(DIK_F4) =              0x3E,
+  API(DIK_F5) =              0x3F,
+  API(DIK_F6) =              0x40,
+  API(DIK_F7) =              0x41,
+  API(DIK_F8) =              0x42,
+  API(DIK_F9) =              0x43,
+  API(DIK_F10) =             0x44,
+  API(DIK_NUMLOCK) =         0x45,
+  API(DIK_SCROLL) =          0x46,    /* Scroll Lock */
+  API(DIK_NUMPAD7) =         0x47,
+  API(DIK_NUMPAD8) =         0x48,
+  API(DIK_NUMPAD9) =         0x49,
+  API(DIK_SUBTRACT) =        0x4A,    /* - on numeric keypad */
+  API(DIK_NUMPAD4) =         0x4B,
+  API(DIK_NUMPAD5) =         0x4C,
+  API(DIK_NUMPAD6) =         0x4D,
+  API(DIK_ADD) =             0x4E,    /* + on numeric keypad */
+  API(DIK_NUMPAD1) =         0x4F,
+  API(DIK_NUMPAD2) =         0x50,
+  API(DIK_NUMPAD3) =         0x51,
+  API(DIK_NUMPAD0) =         0x52,
+  API(DIK_DECIMAL) =         0x53,    /* . on numeric keypad */
+  API(DIK_OEM_102) =         0x56,    /* < > | on UK/Germany keyboards */
+  API(DIK_F11) =             0x57,
+  API(DIK_F12) =             0x58,
 
-#define DIK_F13             0x64    /*                     (NEC PC98) */
-#define DIK_F14             0x65    /*                     (NEC PC98) */
-#define DIK_F15             0x66    /*                     (NEC PC98) */
+  API(DIK_F13) =             0x64,    /*                     (NEC PC98) */
+  API(DIK_F14) =             0x65,    /*                     (NEC PC98) */
+  API(DIK_F15) =             0x66,    /*                     (NEC PC98) */
 
-#define DIK_KANA            0x70    /* (Japanese keyboard)            */
-#define DIK_ABNT_C1         0x73    /* / ? on Portugese (Brazilian) keyboards */
-#define DIK_CONVERT         0x79    /* (Japanese keyboard)            */
-#define DIK_NOCONVERT       0x7B    /* (Japanese keyboard)            */
-#define DIK_YEN             0x7D    /* (Japanese keyboard)            */
-#define DIK_ABNT_C2         0x7E    /* Numpad . on Portugese (Brazilian) keyboards */
-#define DIK_NUMPADEQUALS    0x8D    /* = on numeric keypad (NEC PC98) */
-#define DIK_PREVTRACK       0x90    /* Previous Track (DIK_CIRCUMFLEX on Japanese keyboard) */
-#define DIK_AT              0x91    /*                     (NEC PC98) */
-#define DIK_COLON           0x92    /*                     (NEC PC98) */
-#define DIK_UNDERLINE       0x93    /*                     (NEC PC98) */
-#define DIK_KANJI           0x94    /* (Japanese keyboard)            */
-#define DIK_STOP            0x95    /*                     (NEC PC98) */
-#define DIK_AX              0x96    /*                     (Japan AX) */
-#define DIK_UNLABELED       0x97    /*                        (J3100) */
-#define DIK_NEXTTRACK       0x99    /* Next Track */
-#define DIK_NUMPADENTER     0x9C    /* Enter on numeric keypad */
-#define DIK_RCONTROL        0x9D
-#define DIK_MUTE            0xA0    /* Mute */
-#define DIK_CALCULATOR      0xA1    /* Calculator */
-#define DIK_PLAYPAUSE       0xA2    /* Play / Pause */
-#define DIK_MEDIASTOP       0xA4    /* Media Stop */
-#define DIK_VOLUMEDOWN      0xAE    /* Volume - */
-#define DIK_VOLUMEUP        0xB0    /* Volume + */
-#define DIK_WEBHOME         0xB2    /* Web home */
-#define DIK_NUMPADCOMMA     0xB3    /* , on numeric keypad (NEC PC98) */
-#define DIK_DIVIDE          0xB5    /* / on numeric keypad */
-#define DIK_SYSRQ           0xB7
-#define DIK_RMENU           0xB8    /* right Alt */
-#define DIK_PAUSE           0xC5    /* Pause */
-#define DIK_HOME            0xC7    /* Home on arrow keypad */
-#define DIK_UP              0xC8    /* UpArrow on arrow keypad */
-#define DIK_PRIOR           0xC9    /* PgUp on arrow keypad */
-#define DIK_LEFT            0xCB    /* LeftArrow on arrow keypad */
-#define DIK_RIGHT           0xCD    /* RightArrow on arrow keypad */
-#define DIK_END             0xCF    /* End on arrow keypad */
-#define DIK_DOWN            0xD0    /* DownArrow on arrow keypad */
-#define DIK_NEXT            0xD1    /* PgDn on arrow keypad */
-#define DIK_INSERT          0xD2    /* Insert on arrow keypad */
-#define DIK_DELETE          0xD3    /* Delete on arrow keypad */
-#define DIK_LWIN            0xDB    /* Left Windows key */
-#define DIK_RWIN            0xDC    /* Right Windows key */
-#define DIK_APPS            0xDD    /* AppMenu key */
-#define DIK_POWER           0xDE    /* System Power */
-#define DIK_SLEEP           0xDF    /* System Sleep */
-#define DIK_WAKE            0xE3    /* System Wake */
-#define DIK_WEBSEARCH       0xE5    /* Web Search */
-#define DIK_WEBFAVORITES    0xE6    /* Web Favorites */
-#define DIK_WEBREFRESH      0xE7    /* Web Refresh */
-#define DIK_WEBSTOP         0xE8    /* Web Stop */
-#define DIK_WEBFORWARD      0xE9    /* Web Forward */
-#define DIK_WEBBACK         0xEA    /* Web Back */
-#define DIK_MYCOMPUTER      0xEB    /* My Computer */
-#define DIK_MAIL            0xEC    /* Mail */
-#define DIK_MEDIASELECT     0xED    /* Media Select */
+  API(DIK_KANA) =            0x70,    /* (Japanese keyboard)            */
+  API(DIK_ABNT_C1) =         0x73,    /* / ? on Portugese (Brazilian) keyboards */
+  API(DIK_CONVERT) =         0x79,    /* (Japanese keyboard)            */
+  API(DIK_NOCONVERT) =       0x7B,    /* (Japanese keyboard)            */
+  API(DIK_YEN) =             0x7D,    /* (Japanese keyboard)            */
+  API(DIK_ABNT_C2) =         0x7E,    /* Numpad . on Portugese (Brazilian) keyboards */
+  API(DIK_NUMPADEQUALS) =    0x8D,    /* = on numeric keypad (NEC PC98) */
+  API(DIK_PREVTRACK) =       0x90,    /* Previous Track (DIK_CIRCUMFLEX on Japanese keyboard) */
+  API(DIK_AT) =              0x91,    /*                     (NEC PC98) */
+  API(DIK_COLON) =           0x92,    /*                     (NEC PC98) */
+  API(DIK_UNDERLINE) =       0x93,    /*                     (NEC PC98) */
+  API(DIK_KANJI) =           0x94,    /* (Japanese keyboard)            */
+  API(DIK_STOP) =            0x95,    /*                     (NEC PC98) */
+  API(DIK_AX) =              0x96,    /*                     (Japan AX) */
+  API(DIK_UNLABELED) =       0x97,    /*                        (J3100) */
+  API(DIK_NEXTTRACK) =       0x99,    /* Next Track */
+  API(DIK_NUMPADENTER) =     0x9C,    /* Enter on numeric keypad */
+  API(DIK_RCONTROL) =        0x9D,
+  API(DIK_MUTE) =            0xA0,    /* Mute */
+  API(DIK_CALCULATOR) =      0xA1,    /* Calculator */
+  API(DIK_PLAYPAUSE) =       0xA2,    /* Play / Pause */
+  API(DIK_MEDIASTOP) =       0xA4,    /* Media Stop */
+  API(DIK_VOLUMEDOWN) =      0xAE,    /* Volume - */
+  API(DIK_VOLUMEUP) =        0xB0,    /* Volume + */
+  API(DIK_WEBHOME) =         0xB2,    /* Web home */
+  API(DIK_NUMPADCOMMA) =     0xB3,    /* , on numeric keypad (NEC PC98) */
+  API(DIK_DIVIDE) =          0xB5,    /* / on numeric keypad */
+  API(DIK_SYSRQ) =           0xB7,
+  API(DIK_RMENU) =           0xB8,    /* right Alt */
+  API(DIK_PAUSE) =           0xC5,    /* Pause */
+  API(DIK_HOME) =            0xC7,    /* Home on arrow keypad */
+  API(DIK_UP) =              0xC8,    /* UpArrow on arrow keypad */
+  API(DIK_PRIOR) =           0xC9,    /* PgUp on arrow keypad */
+  API(DIK_LEFT) =            0xCB,    /* LeftArrow on arrow keypad */
+  API(DIK_RIGHT) =           0xCD,    /* RightArrow on arrow keypad */
+  API(DIK_END) =             0xCF,    /* End on arrow keypad */
+  API(DIK_DOWN) =            0xD0,    /* DownArrow on arrow keypad */
+  API(DIK_NEXT) =            0xD1,    /* PgDn on arrow keypad */
+  API(DIK_INSERT) =          0xD2,    /* Insert on arrow keypad */
+  API(DIK_DELETE) =          0xD3,    /* Delete on arrow keypad */
+  API(DIK_LWIN) =            0xDB,    /* Left Windows key */
+  API(DIK_RWIN) =            0xDC,    /* Right Windows key */
+  API(DIK_APPS) =            0xDD,    /* AppMenu key */
+  API(DIK_POWER) =           0xDE,    /* System Power */
+  API(DIK_SLEEP) =           0xDF,    /* System Sleep */
+  API(DIK_WAKE) =            0xE3,    /* System Wake */
+  API(DIK_WEBSEARCH) =       0xE5,    /* Web Search */
+  API(DIK_WEBFAVORITES) =    0xE6,    /* Web Favorites */
+  API(DIK_WEBREFRESH) =      0xE7,    /* Web Refresh */
+  API(DIK_WEBSTOP) =         0xE8,    /* Web Stop */
+  API(DIK_WEBFORWARD) =      0xE9,    /* Web Forward */
+  API(DIK_WEBBACK) =         0xEA,    /* Web Back */
+  API(DIK_MYCOMPUTER) =      0xEB,    /* My Computer */
+  API(DIK_MAIL) =            0xEC,    /* Mail */
+  API(DIK_MEDIASELECT) =     0xED,    /* Media Select */
 
 /*
  *  Alternate names for keys, to facilitate transition from DOS.
  */
-#define DIK_BACKSPACE       DIK_BACK            /* backspace */
-#define DIK_NUMPADSTAR      DIK_MULTIPLY        /* * on numeric keypad */
-#define DIK_LALT            DIK_LMENU           /* left Alt */
-#define DIK_CAPSLOCK        DIK_CAPITAL         /* CapsLock */
-#define DIK_NUMPADMINUS     DIK_SUBTRACT        /* - on numeric keypad */
-#define DIK_NUMPADPLUS      DIK_ADD             /* + on numeric keypad */
-#define DIK_NUMPADPERIOD    DIK_DECIMAL         /* . on numeric keypad */
-#define DIK_NUMPADSLASH     DIK_DIVIDE          /* / on numeric keypad */
-#define DIK_RALT            DIK_RMENU           /* right Alt */
-#define DIK_UPARROW         DIK_UP              /* UpArrow on arrow keypad */
-#define DIK_PGUP            DIK_PRIOR           /* PgUp on arrow keypad */
-#define DIK_LEFTARROW       DIK_LEFT            /* LeftArrow on arrow keypad */
-#define DIK_RIGHTARROW      DIK_RIGHT           /* RightArrow on arrow keypad */
-#define DIK_DOWNARROW       DIK_DOWN            /* DownArrow on arrow keypad */
-#define DIK_PGDN            DIK_NEXT            /* PgDn on arrow keypad */
+  API(DIK_BACKSPACE) =       API(DIK_BACK),            /* backspace */
+  API(DIK_NUMPADSTAR) =      API(DIK_MULTIPLY),        /* * on numeric keypad */
+  API(DIK_LALT) =            API(DIK_LMENU),           /* left Alt */
+  API(DIK_CAPSLOCK) =        API(DIK_CAPITAL),         /* CapsLock */
+  API(DIK_NUMPADMINUS) =     API(DIK_SUBTRACT),        /* - on numeric keypad */
+  API(DIK_NUMPADPLUS) =      API(DIK_ADD),             /* + on numeric keypad */
+  API(DIK_NUMPADPERIOD) =    API(DIK_DECIMAL),         /* . on numeric keypad */
+  API(DIK_NUMPADSLASH) =     API(DIK_DIVIDE),          /* / on numeric keypad */
+  API(DIK_RALT) =            API(DIK_RMENU),           /* right Alt */
+  API(DIK_UPARROW) =         API(DIK_UP),              /* UpArrow on arrow keypad */
+  API(DIK_PGUP) =            API(DIK_PRIOR),           /* PgUp on arrow keypad */
+  API(DIK_LEFTARROW) =       API(DIK_LEFT),            /* LeftArrow on arrow keypad */
+  API(DIK_RIGHTARROW) =      API(DIK_RIGHT),           /* RightArrow on arrow keypad */
+  API(DIK_DOWNARROW) =       API(DIK_DOWN),            /* DownArrow on arrow keypad */
+  API(DIK_PGDN) =            API(DIK_NEXT),            /* PgDn on arrow keypad */
 
 /*
  *  Alternate names for keys originally not used on US keyboards.
  */
-#define DIK_CIRCUMFLEX      DIK_PREVTRACK       /* Japanese keyboard */
+  API(DIK_CIRCUMFLEX) =      API(DIK_PREVTRACK)        /* Japanese keyboard */
+};
 
 #endif

--- a/dll/kernel32.c
+++ b/dll/kernel32.c
@@ -4,7 +4,7 @@
 #include "../emulation.h"
 
 // 0x8704A0
-EXPORT_STDCALL(kernel32, DWORD, GetVersion) { // WINAPI
+EXPORT_STDCALL(kernel32, API(DWORD), GetVersion) { // WINAPI
 // Windows 98 (https://support.microsoft.com/en-us/kb/189249)
   uint16_t platformId = 1;
   uint8_t majorVersion = 4;
@@ -13,13 +13,13 @@ EXPORT_STDCALL(kernel32, DWORD, GetVersion) { // WINAPI
 }
 
 // 0x8704F8
-EXPORT_STDCALL(kernel32, LPTSTR, GetCommandLineA) { //WINAPI
+EXPORT_STDCALL(kernel32, API(LPTSTR), GetCommandLineA) { //WINAPI
   //return "program"; //FIXME!
   return 0;
 }
 
 // 0x8704F4
-EXPORT_STDCALL(kernel32, VOID, GetStartupInfo, LPSTARTUPINFO,lpStartupInfo) { //WINAPI
+EXPORT_STDCALL(kernel32, API(VOID), GetStartupInfo, API(LPSTARTUPINFO),lpStartupInfo) { //WINAPI
   //lpStartupInfo->
 }
 

--- a/emulation.h
+++ b/emulation.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#define API(x) API__ ## x
+
 //FIXME: use these..
 typedef uint32_t Address;
 typedef uint32_t Size;

--- a/exe.h
+++ b/exe.h
@@ -80,14 +80,14 @@ typedef struct {
 	uint32_t forwarderChain;
 	uint32_t name;
 	uint32_t firstThunk;
-} IMAGE_IMPORT_DESCRIPTOR;
+} API(IMAGE_IMPORT_DESCRIPTOR);
 
 typedef struct  {
 	uint16_t hint;
 	char name[];
-} IMAGE_IMPORT_BY_NAME;
+} API(IMAGE_IMPORT_BY_NAME);
 
 typedef struct {
   uint32_t virtualAddress;
   uint32_t sizeOfBlock;
-} IMAGE_BASE_RELOCATION;
+} API(IMAGE_BASE_RELOCATION);

--- a/main.c
+++ b/main.c
@@ -930,14 +930,14 @@ HACKY_IMPORT_BEGIN(CoCreateInstance)
   hacky_printf("dwClsContext 0x%" PRIX32 "\n", stack[3]);
   hacky_printf("riid 0x%" PRIX32 "\n", stack[4]);
   hacky_printf("ppv 0x%" PRIX32 "\n", stack[5]);
-  const CLSID* clsid = (const CLSID*)Memory(stack[1]);
+  const API(CLSID)* clsid = (const API(CLSID)*)Memory(stack[1]);
   char clsidString[1024];
   sprintf(clsidString, "%08" PRIX32 "-%04" PRIX16 "-%04" PRIX16 "-%02" PRIX8 "%02" PRIX8 "-%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8,
           clsid->Data1, clsid->Data2, clsid->Data3,
           clsid->Data4[0], clsid->Data4[1], clsid->Data4[2], clsid->Data4[3],
           clsid->Data4[4], clsid->Data4[5], clsid->Data4[6], clsid->Data4[7]);
   printf("  (read clsid: {%s})\n", clsidString);
-  const IID* iid = (const IID*)Memory(stack[4]);
+  const API(IID)* iid = (const API(IID)*)Memory(stack[4]);
   char iidString[1024];
   sprintf(iidString, "%08" PRIX32 "-%04" PRIX16 "-%04" PRIX16 "-%02" PRIX8 "%02" PRIX8 "-%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8,
           iid->Data1, iid->Data2, iid->Data3,
@@ -1149,7 +1149,7 @@ HACKY_IMPORT_BEGIN(StretchBlt)
 
   // Get the pointer to the object the DC points at, we'll assume that it is a BITMAP
   Address objectAddress = *(Address*)Memory(stack[6]);
-  BITMAP* bitmap = Memory(objectAddress);
+  API(BITMAP)* bitmap = Memory(objectAddress);
   void* data = Memory(bitmap->bmBits);
 
   // Update the texture interface
@@ -1505,7 +1505,7 @@ HACKY_IMPORT_BEGIN(FindFirstFileA)
   }
 
   if (*dirlisting) {
-    WIN32_FIND_DATA* data = Memory(stack[2]);
+    API(WIN32_FIND_DATA)* data = Memory(stack[2]);
     data->dwFileAttributes = strchr(*dirlisting,'.') ? 0x80 : 0x10; // FILE_ATTRIBUTE_NORMAL or FILE_ATTRIBUTE_DIRECTORY
     sprintf(data->cFileName, "%s", *dirlisting);
     dirlisting++;
@@ -1522,7 +1522,7 @@ HACKY_IMPORT_BEGIN(FindNextFileA)
   hacky_printf("lpFindFileData 0x%" PRIX32 "\n", stack[2]);
 
   if (*dirlisting) {
-    WIN32_FIND_DATA* data = Memory(stack[2]);
+    API(WIN32_FIND_DATA)* data = Memory(stack[2]);
     data->dwFileAttributes = strchr(*dirlisting,'.') ? 0x80 : 0x10; // FILE_ATTRIBUTE_NORMAL or FILE_ATTRIBUTE_DIRECTORY
     sprintf(data->cFileName, "%s", *dirlisting);
     dirlisting++;
@@ -1546,12 +1546,12 @@ HACKY_IMPORT_END()
 // Name entry screen
 
 HACKY_IMPORT_BEGIN(GetKeyState)
-  SHORT pressed = 0x8000; // high order bit = pressed
-  SHORT toggled = 0x0001; // low order bit = toggled
-  SHORT returnValue = 0; // default: unpressed
+  API(SHORT) pressed = 0x8000; // high order bit = pressed
+  API(SHORT) toggled = 0x0001; // low order bit = toggled
+  API(SHORT) returnValue = 0; // default: unpressed
   int nVirtKey = stack[1];
   switch(nVirtKey) {
-    case 0x14: // VK_CAPITAL
+    case API(VK_CAPITAL):
       returnValue = 0;
       break;
     default:
@@ -1562,21 +1562,21 @@ HACKY_IMPORT_BEGIN(GetKeyState)
 HACKY_IMPORT_END()
 
 HACKY_IMPORT_BEGIN(MapVirtualKeyA)
-  UINT uCode = stack[1];
-  UINT uMapType = stack[2];
+  API(UINT) uCode = stack[1];
+  API(UINT) uMapType = stack[2];
 
   hacky_printf("uCode 0x%" PRIX32 "\n", uCode);
   hacky_printf("uMapType 0x%" PRIX32 "\n", uMapType);
 
-  UINT returnValue = 0; // 0 = no map
+  API(UINT) returnValue = 0; // 0 = no map
   switch(uMapType) {
     case 1: // MAPVK_VSC_TO_VK: uCode is a scan code and is translated into a virtual-key code that does not distinguish between left- and right-hand keys. If there is no translation, the function returns 0.
-      if (uCode == VK_LSHIFT || uCode == VK_RSHIFT) {
-        returnValue = VK_SHIFT;
-      } else if (uCode == VK_LCONTROL || uCode == VK_RCONTROL) {
-        returnValue = VK_CONTROL;
-      } else if (uCode == VK_LMENU || uCode == VK_RMENU) {
-        returnValue = VK_MENU;
+      if (uCode == API(VK_LSHIFT) || uCode == API(VK_RSHIFT)) {
+        returnValue = API(VK_SHIFT);
+      } else if (uCode == API(VK_LCONTROL) || uCode == API(VK_RCONTROL)) {
+        returnValue = API(VK_CONTROL);
+      } else if (uCode == API(VK_LMENU) || uCode == API(VK_RMENU)) {
+        returnValue = API(VK_MENU);
       } else {
         returnValue = uCode; // FIXME: is this okay?
       }
@@ -1737,7 +1737,7 @@ HACKY_COM_BEGIN(IDirectDraw4, 0)
   hacky_printf("p 0x%" PRIX32 "\n", stack[1]);
   hacky_printf("riid 0x%" PRIX32 "\n", stack[2]);
   hacky_printf("ppvObj 0x%" PRIX32 "\n", stack[3]);
-  const IID* iid = (const IID*)Memory(stack[2]);
+  const API(IID)* iid = (const API(IID)*)Memory(stack[2]);
 
   char iidString[1024];
   sprintf(iidString, "%08" PRIX32 "-%04" PRIX16 "-%04" PRIX16 "-%02" PRIX8 "%02" PRIX8 "-%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8,
@@ -1788,11 +1788,11 @@ HACKY_COM_BEGIN(IDirectDraw4, 6)
   hacky_printf("c 0x%" PRIX32 "\n", stack[4]);
 
   Address surfaceAddress = CreateInterface("IDirectDrawSurface4", 50);
-  DirectDrawSurface4* surface = (DirectDrawSurface4*)Memory(surfaceAddress);
+  API(DirectDrawSurface4)* surface = (API(DirectDrawSurface4)*)Memory(surfaceAddress);
 
   *(Address*)Memory(stack[3]) = surfaceAddress;
 
-  DDSURFACEDESC2* desc = (DDSURFACEDESC2*)Memory(stack[2]);
+  API(DDSURFACEDESC2)* desc = (API(DDSURFACEDESC2)*)Memory(stack[2]);
 
   printf("dwSize = %" PRIu32 "\n", desc->dwSize);
   printf("dwFlags = 0x%08" PRIX32 "\n", desc->dwFlags);
@@ -1810,17 +1810,17 @@ HACKY_COM_BEGIN(IDirectDraw4, 6)
   printf("ddpfPixelFormat.dwRGBAlphaBitMask = 0x%08" PRIX32 "\n", desc->ddpfPixelFormat.dwRGBAlphaBitMask);
 
 
-  memcpy(&surface->desc, desc, sizeof(DDSURFACEDESC2));
+  memcpy(&surface->desc, desc, sizeof(API(DDSURFACEDESC2)));
 
-  #define DDSD_PITCH 0x00000008l
+  #define API__DDSD_PITCH 0x00000008l
 
-  surface->desc.dwFlags = DDSD_PITCH;
+  surface->desc.dwFlags = API(DDSD_PITCH);
   surface->desc.lPitch = surface->desc.dwWidth * desc->ddpfPixelFormat.dwRGBBitCount / 8;
 
-  if (desc->ddsCaps.dwCaps & DDSCAPS_TEXTURE) {
+  if (desc->ddsCaps.dwCaps & API(DDSCAPS_TEXTURE)) {
     // FIXME: Delay this until the interface is queried the first time?!
     surface->texture = CreateInterface("IDirect3DTexture2", 20);
-    Direct3DTexture2* texture = (Direct3DTexture2*)Memory(surface->texture);
+    API(Direct3DTexture2)* texture = (API(Direct3DTexture2)*)Memory(surface->texture);
     texture->surface = surfaceAddress;
     glGenTextures(1, &texture->handle);
     printf("GL handle is %d\n", texture->handle);
@@ -1829,7 +1829,7 @@ HACKY_COM_BEGIN(IDirectDraw4, 6)
     surface->texture = CreateInterface("invalid", 200);
 
     //FIXME: WTF is this shit?!
-    Direct3DTexture2* texture = (Direct3DTexture2*)Memory(surface->texture);
+    API(Direct3DTexture2)* texture = (API(Direct3DTexture2)*)Memory(surface->texture);
     glGenTextures(1, &texture->handle);
     //assert(false);
   }
@@ -1864,14 +1864,14 @@ HACKY_COM_BEGIN(IDirectDraw4, 8)
     *(uint32_t*)Memory(esp) = c; // user pointer
 
     esp -= 4;
-    Address descAddress = Allocate(sizeof(DDSURFACEDESC2));
-    DDSURFACEDESC2* desc = Memory(descAddress);
-    desc->ddpfPixelFormat.dwFlags = DDPF_RGB;
+    Address descAddress = Allocate(sizeof(API(DDSURFACEDESC2)));
+    API(DDSURFACEDESC2)* desc = Memory(descAddress);
+    desc->ddpfPixelFormat.dwFlags = API(DDPF_RGB);
     desc->ddpfPixelFormat.dwRGBBitCount = 24;
     desc->dwWidth = 640;
     desc->dwHeight = 480;
     desc->lpSurface = 0x01010101;
-    *(uint32_t*)Memory(esp) = descAddress; // DDSURFACEDESC2*
+    *(uint32_t*)Memory(esp) = descAddress; // API(DDSURFACEDESC2)*
 
     // Emulate the call
     esp -= 4;
@@ -1907,10 +1907,10 @@ HACKY_COM_BEGIN(IDirectDraw4, 11)
 // (+60)
 
 #if 1
-  DDCAPS* halCaps = Memory(stack[2]);
-  DDCAPS* swCaps = Memory(stack[3]);
+  API(DDCAPS)* halCaps = Memory(stack[2]);
+  API(DDCAPS)* swCaps = Memory(stack[3]);
 
-  printf("halCaps is %d bytes (known: %d bytes)\n", halCaps->dwSize, sizeof(DDCAPS));
+  printf("halCaps is %d bytes (known: %d bytes)\n", halCaps->dwSize, sizeof(API(DDCAPS)));
 
   halCaps->dwCaps = 0x00000001;
   halCaps->dwCaps2 = 0x00080000;
@@ -1992,8 +1992,8 @@ HACKY_COM_BEGIN(IDirectDrawSurface4, 0)
   hacky_printf("p 0x%" PRIX32 "\n", stack[1]);
   hacky_printf("a 0x%" PRIX32 "\n", stack[2]);
   hacky_printf("b 0x%" PRIX32 "\n", stack[3]);
-  DirectDrawSurface4* this = (DirectDrawSurface4*)Memory(stack[1]);
-  const IID* iid = (const IID*)Memory(stack[2]);
+  API(DirectDrawSurface4)* this = (API(DirectDrawSurface4)*)Memory(stack[1]);
+  const API(IID)* iid = (const API(IID)*)Memory(stack[2]);
   printf("  (read iid: {%08" PRIX32 "-%04" PRIX16 "-%04" PRIX16 "-%02" PRIX8 "%02" PRIX8 "-%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "})\n",
          iid->Data1, iid->Data2, iid->Data3,
          iid->Data4[0], iid->Data4[1], iid->Data4[2], iid->Data4[3],
@@ -2076,18 +2076,18 @@ HACKY_COM_BEGIN(IDirectDrawSurface4, 12)
   hacky_printf("p 0x%" PRIX32 "\n", stack[1]);
   hacky_printf("a 0x%" PRIX32 "\n", stack[2]);
   hacky_printf("b 0x%" PRIX32 "\n", stack[3]);
-  DDSCAPS2* caps = (DDSCAPS2*)Memory(stack[2]);
+  API(DDSCAPS2)* caps = (API(DDSCAPS2)*)Memory(stack[2]);
 
   printf("dwCaps = 0x%08" PRIX32 "\n", caps->dwCaps);
 
-  if (caps->dwCaps & DDSCAPS_MIPMAP) {
+  if (caps->dwCaps & API(DDSCAPS_MIPMAP)) {
     //FIXME: This is probably BAD!
     printf("Redirecting to itself\n");
     *(Address*)Memory(stack[3]) = stack[1];
   } else {
     printf("Creating new dummy surface\n");
     Address surfaceAddress = CreateInterface("IDirectDrawSurface4", 50);
-    DirectDrawSurface4* surface = (DirectDrawSurface4*)Memory(surfaceAddress);
+    API(DirectDrawSurface4)* surface = (API(DirectDrawSurface4)*)Memory(surfaceAddress);
     surface->texture = 0;
     *(Address*)Memory(stack[3]) = surfaceAddress;
   }
@@ -2101,9 +2101,9 @@ HACKY_COM_BEGIN(IDirectDrawSurface4, 17)
   hacky_printf("p 0x%" PRIX32 "\n", stack[1]);
   hacky_printf("a 0x%" PRIX32 "\n", stack[2]);
 
-  DirectDrawSurface4* this = (DirectDrawSurface4*)Memory(stack[1]);
+  API(DirectDrawSurface4)* this = (API(DirectDrawSurface4)*)Memory(stack[1]);
   if (this->texture != 0) {
-    Direct3DTexture2* texture = (Direct3DTexture2*)Memory(this->texture);
+    API(Direct3DTexture2)* texture = (API(Direct3DTexture2)*)Memory(this->texture);
     printf("Returning GL tex handle %d\n", texture->handle);
     *(Address*)Memory(stack[2]) = texture->handle;
   } else {
@@ -2120,7 +2120,7 @@ HACKY_COM_BEGIN(IDirectDrawSurface4, 22)
   hacky_printf("p 0x%" PRIX32 "\n", stack[1]);
   hacky_printf("a 0x%" PRIX32 "\n", stack[2]);
 
-  DDSURFACEDESC2* desc = (DDSURFACEDESC2*)Memory(stack[2]);
+  API(DDSURFACEDESC2)* desc = (API(DDSURFACEDESC2)*)Memory(stack[2]);
   //FIXME?!  
 
   eax = 0; // FIXME: No idea what this expects to return..
@@ -2135,7 +2135,7 @@ HACKY_COM_BEGIN(IDirectDrawSurface4, 25)
   hacky_printf("c 0x%" PRIX32 "\n", stack[4]);
   hacky_printf("d 0x%" PRIX32 "\n", stack[5]);
 
-  DirectDrawSurface4* this = (DirectDrawSurface4*)Memory(stack[1]);
+  API(DirectDrawSurface4)* this = (API(DirectDrawSurface4)*)Memory(stack[1]);
 
   assert(stack[2] == 0);
   assert(stack[5] == 0);
@@ -2146,8 +2146,8 @@ HACKY_COM_BEGIN(IDirectDrawSurface4, 25)
     memset(Memory(this->desc.lpSurface), 0x77, this->desc.dwHeight * this->desc.lPitch);
   }
 
-  DDSURFACEDESC2* desc = Memory(stack[3]);
-  memcpy(desc, &this->desc, sizeof(DDSURFACEDESC2));
+  API(DDSURFACEDESC2)* desc = Memory(stack[3]);
+  memcpy(desc, &this->desc, sizeof(API(DDSURFACEDESC2)));
   
   printf("%d x %d (pitch: %d); bpp = %d; at 0x%08X\n", desc->dwWidth, desc->dwHeight, desc->lPitch, desc->ddpfPixelFormat.dwRGBBitCount, desc->lpSurface);
 #if 0
@@ -2177,11 +2177,11 @@ HACKY_COM_BEGIN(IDirectDrawSurface4, 32)
 
   assert(stack[2] == 0);
 
-  DirectDrawSurface4* this = (DirectDrawSurface4*)Memory(stack[1]);
+  API(DirectDrawSurface4)* this = (API(DirectDrawSurface4)*)Memory(stack[1]);
 
-  DDSURFACEDESC2* desc = &this->desc;
+  API(DDSURFACEDESC2)* desc = &this->desc;
 
-  Direct3DTexture2* texture = (Direct3DTexture2*)Memory(this->texture);
+  API(Direct3DTexture2)* texture = (API(Direct3DTexture2)*)Memory(this->texture);
 
   GLint previousTexture = 0;
   glGetIntegerv(GL_TEXTURE_BINDING_2D, &previousTexture);
@@ -2257,10 +2257,10 @@ HACKY_COM_BEGIN(IDirect3D3, 3)
     esp -= 4;
     *(uint32_t*)Memory(esp) = b; // lpContext
 
-    Address desc_addr = Allocate(sizeof(D3DDEVICEDESC));
-    D3DDEVICEDESC* desc = (D3DDEVICEDESC*)Memory(desc_addr);
-    memset(desc, 0x00, sizeof(D3DDEVICEDESC));
-    desc->dwSize = sizeof(D3DDEVICEDESC);
+    Address desc_addr = Allocate(sizeof(API(D3DDEVICEDESC)));
+    API(D3DDEVICEDESC)* desc = (API(D3DDEVICEDESC)*)Memory(desc_addr);
+    memset(desc, 0x00, sizeof(API(D3DDEVICEDESC)));
+    desc->dwSize = sizeof(API(D3DDEVICEDESC));
     desc->dwFlags = 0xFFFFFFFF;
 
     desc->dwDeviceZBufferBitDepth = 24;
@@ -2310,9 +2310,9 @@ HACKY_COM_BEGIN(IDirect3D3, 3)
 
     // Used as parameter in Direct Draw `Initialize`
     esp -= 4;
-    Address guid_addr = Allocate(sizeof(IID));
-    IID* guid = (IID*)Memory(guid_addr);
-IID* iid = guid;
+    Address guid_addr = Allocate(sizeof(API(IID)));
+    API(IID)* guid = (API(IID)*)Memory(guid_addr);
+API(IID)* iid = guid;
 
 // IDirect3DHALDevice
 iid->Data1 = 0x84E63DE0;
@@ -2383,16 +2383,16 @@ HACKY_COM_BEGIN(IDirect3D3, 10)
   *(uint32_t*)Memory(esp) = returnAddress;
 
   {
-    Address formatAddress = Allocate(sizeof(DDPIXELFORMAT));
-    DDPIXELFORMAT* format = (DDPIXELFORMAT*)Memory(formatAddress);
-    format->dwSize = sizeof(DDPIXELFORMAT);
+    Address formatAddress = Allocate(sizeof(API(DDPIXELFORMAT)));
+    API(DDPIXELFORMAT)* format = (API(DDPIXELFORMAT)*)Memory(formatAddress);
+    format->dwSize = sizeof(API(DDPIXELFORMAT));
     format->dwFlags = 0x400; // DDPF_ZBUFFER;
     format->dwZBufferBitDepth = 16;
 
     esp -= 4;
     *(uint32_t*)Memory(esp) = c; // user pointer
     esp -= 4;
-    *(uint32_t*)Memory(esp) = formatAddress; // DDPIXELFORMAT*
+    *(uint32_t*)Memory(esp) = formatAddress; // API(DDPIXELFORMAT)*
 
     // Emulate the call
     esp -= 4;
@@ -2422,8 +2422,8 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 0)
   hacky_printf("p 0x%" PRIX32 "\n", stack[1]);
   hacky_printf("a 0x%" PRIX32 "\n", stack[2]);
   hacky_printf("b 0x%" PRIX32 "\n", stack[3]);
-  DirectDrawSurface4* this = (DirectDrawSurface4*)Memory(stack[1]);
-  const IID* iid = (const IID*)Memory(stack[2]);
+  API(DirectDrawSurface4)* this = (API(DirectDrawSurface4)*)Memory(stack[1]);
+  const API(IID)* iid = (const API(IID)*)Memory(stack[2]);
   printf("  (read iid: {%08" PRIX32 "-%04" PRIX16 "-%04" PRIX16 "-%02" PRIX8 "%02" PRIX8 "-%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "})\n",
      iid->Data1, iid->Data2, iid->Data3,
      iid->Data4[0], iid->Data4[1], iid->Data4[2], iid->Data4[3],
@@ -2484,11 +2484,11 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 8)
 
   {
     {
-      Address formatAddress = Allocate(sizeof(DDPIXELFORMAT));
-      DDPIXELFORMAT* format = (DDPIXELFORMAT*)Memory(formatAddress);
-      memset(format, 0x00, sizeof(DDPIXELFORMAT));
-      format->dwSize = sizeof(DDPIXELFORMAT);
-      format->dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
+      Address formatAddress = Allocate(sizeof(API(DDPIXELFORMAT)));
+      API(DDPIXELFORMAT)* format = (API(DDPIXELFORMAT)*)Memory(formatAddress);
+      memset(format, 0x00, sizeof(API(DDPIXELFORMAT)));
+      format->dwSize = sizeof(API(DDPIXELFORMAT));
+      format->dwFlags = API(DDPF_RGB) | API(DDPF_ALPHAPIXELS);
       format->dwRGBBitCount = 16;
       format->dwRBitMask = 0x0F00;
       format->dwGBitMask = 0x00F0;
@@ -2498,18 +2498,18 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 8)
       esp -= 4;
       *(uint32_t*)Memory(esp) = b; // user pointer
       esp -= 4;
-      *(uint32_t*)Memory(esp) = formatAddress; // DDPIXELFORMAT*
+      *(uint32_t*)Memory(esp) = formatAddress; // API(DDPIXELFORMAT)*
 
       // Emulate a call by setting return address to where we want to go.
       esp -= 4;
       *(uint32_t*)Memory(esp) = clearEax; // Return to clear eax
     }
     {
-      Address formatAddress = Allocate(sizeof(DDPIXELFORMAT));
-      DDPIXELFORMAT* format = (DDPIXELFORMAT*)Memory(formatAddress);
-      memset(format, 0x00, sizeof(DDPIXELFORMAT));
-      format->dwSize = sizeof(DDPIXELFORMAT);
-      format->dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
+      Address formatAddress = Allocate(sizeof(API(DDPIXELFORMAT)));
+      API(DDPIXELFORMAT)* format = (API(DDPIXELFORMAT)*)Memory(formatAddress);
+      memset(format, 0x00, sizeof(API(DDPIXELFORMAT)));
+      format->dwSize = sizeof(API(DDPIXELFORMAT));
+      format->dwFlags = API(DDPF_RGB) | API(DDPF_ALPHAPIXELS);
       format->dwRGBBitCount = 16;
       format->dwRBitMask = 0x7C00;
       format->dwGBitMask = 0x03E0;
@@ -2519,7 +2519,7 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 8)
       esp -= 4;
       *(uint32_t*)Memory(esp) = b; // user pointer
       esp -= 4;
-      *(uint32_t*)Memory(esp) = formatAddress; // DDPIXELFORMAT*
+      *(uint32_t*)Memory(esp) = formatAddress; // API(DDPIXELFORMAT)*
 
       // Emulate a call by setting return address to the callback.
       esp -= 4;
@@ -2527,11 +2527,11 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 8)
     }
 #if 1
     {
-      Address formatAddress = Allocate(sizeof(DDPIXELFORMAT));
-      DDPIXELFORMAT* format = (DDPIXELFORMAT*)Memory(formatAddress);
-      memset(format, 0x00, sizeof(DDPIXELFORMAT));
-      format->dwSize = sizeof(DDPIXELFORMAT);
-      format->dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
+      Address formatAddress = Allocate(sizeof(API(DDPIXELFORMAT)));
+      API(DDPIXELFORMAT)* format = (API(DDPIXELFORMAT)*)Memory(formatAddress);
+      memset(format, 0x00, sizeof(API(DDPIXELFORMAT)));
+      format->dwSize = sizeof(API(DDPIXELFORMAT));
+      format->dwFlags = API(DDPF_RGB) | API(DDPF_ALPHAPIXELS);
       format->dwRGBBitCount = 32;
       format->dwRBitMask = 0x00FF0000;
       format->dwGBitMask = 0x0000FF00;
@@ -2541,7 +2541,7 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 8)
       esp -= 4;
       *(uint32_t*)Memory(esp) = b; // user pointer
       esp -= 4;
-      *(uint32_t*)Memory(esp) = formatAddress; // DDPIXELFORMAT*
+      *(uint32_t*)Memory(esp) = formatAddress; // API(DDPIXELFORMAT)*
 
       // Emulate the call. We are calling the callback.
       // We also set the return address to the callback.
@@ -2587,11 +2587,11 @@ static void glSet(GLenum state, bool set) {
   }
 }
 
-GLenum mapBlend(D3DBLEND blend) {
+GLenum mapBlend(API(D3DBLEND) blend) {
   switch(blend) {
-  case D3DBLEND_SRCALPHA:
+  case API(D3DBLEND_SRCALPHA):
     return GL_SRC_ALPHA;
-  case D3DBLEND_INVSRCALPHA:
+  case API(D3DBLEND_INVSRCALPHA):
     return GL_ONE_MINUS_SRC_ALPHA;
   default:
     assert(false);
@@ -2610,78 +2610,78 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 22)
   uint32_t a = stack[2];
   uint32_t b = stack[3];
   switch(a) {
-    case D3DRS_ZENABLE:
+    case API(D3DRENDERSTATE_ZENABLE):
       //FIXME
       glSet(GL_DEPTH_TEST, b);
       // Hack: While Z is not correct, we can't turn on z-test
       glDisable(GL_DEPTH_TEST);
       break;
 
-    case D3DRS_FILLMODE:
+    case API(D3DRENDERSTATE_FILLMODE):
       assert(b == 3);
       //FIXME
       break;
 
-    case D3DRS_SHADEMODE:
+    case API(D3DRENDERSTATE_SHADEMODE):
       assert(b == 2);
       //FIXME
       break;
 
-    case D3DRS_ZWRITEENABLE:
+    case API(D3DRENDERSTATE_ZWRITEENABLE):
       glDepthMask(b ? GL_TRUE : GL_FALSE);
       break;
 
-    case D3DRS_ALPHATESTENABLE:
+    case API(D3DRENDERSTATE_ALPHATESTENABLE):
       //FIXME: Does not exist in GL 3.3 anymore
       //glSet(GL_ALPHA_TEST, b);
       break;
 
-    case D3DRS_SRCBLEND:
+    case API(D3DRENDERSTATE_SRCBLEND):
       srcBlend = mapBlend(b);
       break;
 
-    case D3DRS_DESTBLEND:
+    case API(D3DRENDERSTATE_DESTBLEND):
       destBlend = mapBlend(b);
       break;
 
-    case D3DRS_CULLMODE:
+    case API(D3DRENDERSTATE_CULLMODE):
       assert(b == 1);
       //FIXME
       break;
 
-    case D3DRS_ZFUNC:
+    case API(D3DRENDERSTATE_ZFUNC):
       assert(b == 4);
       //FIXME
       break;
 
-    case D3DRS_ALPHAFUNC:
+    case API(D3DRENDERSTATE_ALPHAFUNC):
       assert(b == 6);
       //FIXME
       break;
 
-    case D3DRS_DITHERENABLE:
+    case API(D3DRENDERSTATE_DITHERENABLE):
       glSet(GL_DITHER, b);
       break;
 
-    case D3DRS_ALPHABLENDENABLE:
+    case API(D3DRENDERSTATE_ALPHABLENDENABLE):
       glSet(GL_BLEND, b);
       break;
 
     //FIXME: Is this a bug? there doesn't seem to be lighting..
-    case D3DRS_SPECULARENABLE:
+    case API(D3DRENDERSTATE_SPECULARENABLE):
       //FIXME
       break;
 
-    case D3DRENDERSTATE_FOGENABLE:
+    case API(D3DRENDERSTATE_FOGENABLE):
       fogEnable = b;
       break;
-    case D3DRS_FOGCOLOR:
+    case API(D3DRENDERSTATE_FOGCOLOR):
       fogColor = b;
       break;
-    case D3DRS_FOGSTART:
+    case API(D3DRENDERSTATE_FOGTABLESTART):
       fogStart = *(float*)&b;
       break;
-    case D3DRS_FOGEND:
+    case API(D3DRENDERSTATE_FOGTABLEEND):
       fogEnd = *(float*)&b;
       break;
     default:
@@ -2767,7 +2767,7 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 38)
   hacky_printf("b 0x%" PRIX32 "\n", b);
 
   if (b != 0) {
-    Direct3DTexture2* texture = Memory(b);
+    API(Direct3DTexture2)* texture = Memory(b);
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, texture->handle);
   } else {
@@ -2808,7 +2808,7 @@ HACKY_COM_BEGIN(IDirect3DTexture2, 0)
   hacky_printf("a 0x%" PRIX32 "\n", stack[2]);
   hacky_printf("b 0x%" PRIX32 "\n", stack[3]);
 
-  const IID* iid = (const IID*)Memory(stack[2]);
+  const API(IID)* iid = (const API(IID)*)Memory(stack[2]);
 
   char iidString[1024];
   sprintf(iidString, "%08" PRIX32 "-%04" PRIX16 "-%04" PRIX16 "-%02" PRIX8 "%02" PRIX8 "-%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8 "%02" PRIX8,
@@ -2821,7 +2821,7 @@ HACKY_COM_BEGIN(IDirect3DTexture2, 0)
   //FIXME: Add more classed / interfaces
 
   if (!strcmp(iidString, "0B2B8630-AD35-11D0-8EA6-00609797EA5B")) {
-    Direct3DTexture2* this = Memory(stack[1]);
+    API(Direct3DTexture2)* this = Memory(stack[1]);
     *(Address*)Memory(stack[3]) = this->surface;
   } else {
     assert(false);
@@ -2854,8 +2854,8 @@ HACKY_COM_BEGIN(IDirect3DTexture2, 5)
   hacky_printf("p 0x%" PRIX32 "\n", stack[1]);
   hacky_printf("a 0x%" PRIX32 "\n", stack[2]);
 
-  Direct3DTexture2* this = Memory(stack[1]);
-  Direct3DTexture2* a = Memory(stack[2]);
+  API(Direct3DTexture2)* this = Memory(stack[1]);
+  API(Direct3DTexture2)* a = Memory(stack[2]);
   //FIXME: Dirty hack..
   this->handle = a->handle;
   eax = 0; // FIXME: No idea what this expects to return..
@@ -2880,8 +2880,8 @@ HACKY_COM_END()
 HACKY_COM_BEGIN(IDirect3DViewport3, 17)
   hacky_printf("p 0x%" PRIX32 "\n", stack[1]);
   hacky_printf("a 0x%" PRIX32 "\n", stack[2]);
-  D3DVIEWPORT2* vp = (D3DVIEWPORT2*)Memory(stack[2]);
-  assert(vp->dwSize == sizeof(D3DVIEWPORT2));
+  API(D3DVIEWPORT2)* vp = (API(D3DVIEWPORT2)*)Memory(stack[2]);
+  assert(vp->dwSize == sizeof(API(D3DVIEWPORT2)));
 
   clipScale[0] = 2.0f / vp->dvClipWidth;
   clipScale[1] = 2.0f / vp->dvClipHeight;
@@ -2906,13 +2906,13 @@ HACKY_COM_BEGIN(IDirect3DViewport3, 20)
   hacky_printf("f 0x%" PRIX32 "\n", stack[7]);
 
   unsigned int rectCount = stack[2];
-  D3DRECT* rects = Memory(stack[3]);
+  API(D3DRECT)* rects = Memory(stack[3]);
 
   glEnable(GL_SCISSOR_TEST);
   GLint viewport[4];
   glGetIntegerv(GL_VIEWPORT, viewport);
   for(unsigned int i = 0; i < rectCount; i++) {
-    D3DRECT* rect = &rects[i];
+    API(D3DRECT)* rect = &rects[i];
     //FIXME: Clip to viewport..
     int width = rect->x2 - rect->x1;
     int height = rect->y2 -  rect->y1;
@@ -2931,9 +2931,9 @@ HACKY_COM_BEGIN(IDirect3DViewport3, 20)
     glClearStencil(stencilValue);
     glClearDepth(zValue);
     glClearColor(r, g, b, a);
-    glClear(((flags & D3DCLEAR_TARGET) ? GL_COLOR_BUFFER_BIT : 0) |
-            ((flags & D3DCLEAR_ZBUFFER) ? GL_DEPTH_BUFFER_BIT : 0) |
-            ((flags & D3DCLEAR_STENCIL) ? GL_STENCIL_BUFFER_BIT : 0));
+    glClear(((flags & API(D3DCLEAR_TARGET)) ? GL_COLOR_BUFFER_BIT : 0) |
+            ((flags & API(D3DCLEAR_ZBUFFER)) ? GL_DEPTH_BUFFER_BIT : 0) |
+            ((flags & API(D3DCLEAR_STENCIL)) ? GL_STENCIL_BUFFER_BIT : 0));
   }
   glDisable(GL_SCISSOR_TEST);
 
@@ -3000,13 +3000,13 @@ void UpdateKeyboardState() {
   const uint8_t pressed = 0x80; // This is the only requirement for pressed keys
   const uint8_t unpressed = 0x00;
   memset(keyboardState, 0x00, 256);
-  keyboardState[DIK_ESCAPE] = sdlState[SDL_SCANCODE_ESCAPE] ? pressed : unpressed;
-  keyboardState[DIK_RETURN] = sdlState[SDL_SCANCODE_RETURN] ? pressed : unpressed;
-  keyboardState[DIK_SPACE] = sdlState[SDL_SCANCODE_SPACE] ? pressed : unpressed;
-  keyboardState[DIK_UP] = sdlState[SDL_SCANCODE_UP] ? pressed : unpressed;
-  keyboardState[DIK_DOWN] = sdlState[SDL_SCANCODE_DOWN] ? pressed : unpressed;
-  keyboardState[DIK_LEFT] = sdlState[SDL_SCANCODE_LEFT] ? pressed : unpressed;
-  keyboardState[DIK_RIGHT] = sdlState[SDL_SCANCODE_RIGHT] ? pressed : unpressed;
+  keyboardState[API(DIK_ESCAPE)] = sdlState[SDL_SCANCODE_ESCAPE] ? pressed : unpressed;
+  keyboardState[API(DIK_RETURN)] = sdlState[SDL_SCANCODE_RETURN] ? pressed : unpressed;
+  keyboardState[API(DIK_SPACE)] = sdlState[SDL_SCANCODE_SPACE] ? pressed : unpressed;
+  keyboardState[API(DIK_UP)] = sdlState[SDL_SCANCODE_UP] ? pressed : unpressed;
+  keyboardState[API(DIK_DOWN)] = sdlState[SDL_SCANCODE_DOWN] ? pressed : unpressed;
+  keyboardState[API(DIK_LEFT)] = sdlState[SDL_SCANCODE_LEFT] ? pressed : unpressed;
+  keyboardState[API(DIK_RIGHT)] = sdlState[SDL_SCANCODE_RIGHT] ? pressed : unpressed;
 }
 
 // IDirectInputDeviceA -> STDMETHOD(GetDeviceState)(THIS_ DWORD,LPVOID) PURE; // 9
@@ -3040,11 +3040,11 @@ HACKY_COM_BEGIN(IDirectInputDeviceA, 10)
   printf("max count is %d\n", max_count);
   *count = 0;
   unsigned int objectSize = stack[2];
-  assert(objectSize == sizeof(DIDEVICEOBJECTDATA));
+  assert(objectSize == sizeof(API(DIDEVICEOBJECTDATA)));
   for(unsigned int i = 0; i < 256; i++) {
     if (keyboardState[i] != previousState[i]) {
       if (*count < max_count) {
-        DIDEVICEOBJECTDATA objectData;
+        API(DIDEVICEOBJECTDATA) objectData;
         memset(&objectData, 0x00, sizeof(objectData));
         objectData.dwOfs = i;
         objectData.dwData = keyboardState[i];
@@ -3200,15 +3200,15 @@ HACKY_COM_BEGIN(IDirectInputA, 4)
     esp -= 4;
     *(uint32_t*)Memory(esp) = c; // pvRef
 
-    Address ddiAddress = Allocate(sizeof(DIDEVICEINSTANCEA));
-    DIDEVICEINSTANCEA* ddi = Memory(ddiAddress);
-    memset(ddi, 0x00, sizeof(DIDEVICEINSTANCEA));
+    Address ddiAddress = Allocate(sizeof(API(DIDEVICEINSTANCEA)));
+    API(DIDEVICEINSTANCEA)* ddi = Memory(ddiAddress);
+    memset(ddi, 0x00, sizeof(API(DIDEVICEINSTANCEA)));
 
-    ddi->dwSize = sizeof(DIDEVICEINSTANCEA);
+    ddi->dwSize = sizeof(API(DIDEVICEINSTANCEA));
     //FIXME:    GUID guidInstance;
     //FIXME:    GUID guidProduct;
-    #define DIDEVTYPE_KEYBOARD          3
-    ddi->dwDevType = DIDEVTYPE_KEYBOARD; // or something
+    #define API__DIDEVTYPE_KEYBOARD          3
+    ddi->dwDevType = API(DIDEVTYPE_KEYBOARD); // or something
     sprintf(ddi->tszInstanceName, "OpenSWE1R Keyboard 1"); // TCHAR tszInstanceName[MAX_PATH];
     sprintf(ddi->tszProductName, "OpenSWE1R Keyboard"); // TCHAR tszProductName[MAX_PATH];
     //FIXME:    GUID guidFFDriver;
@@ -3425,11 +3425,11 @@ Exe* LoadExe(const char* path) {
     uint32_t relocationRva = exe->peHeader.imageBase + exe->dataDirectories[5].virtualAddress;
     uint32_t remainingSize = exe->dataDirectories[5].size;
 
-    while(remainingSize >= sizeof(IMAGE_BASE_RELOCATION)) {
-      IMAGE_BASE_RELOCATION* baseRelocation = Memory(relocationRva);
-      assert(baseRelocation->sizeOfBlock >= sizeof(IMAGE_BASE_RELOCATION));
+    while(remainingSize >= sizeof(API(IMAGE_BASE_RELOCATION))) {
+      API(IMAGE_BASE_RELOCATION)* baseRelocation = Memory(relocationRva);
+      assert(baseRelocation->sizeOfBlock >= sizeof(API(IMAGE_BASE_RELOCATION)));
 
-      unsigned int relocationCount = (baseRelocation->sizeOfBlock - sizeof(IMAGE_BASE_RELOCATION)) / 2;
+      unsigned int relocationCount = (baseRelocation->sizeOfBlock - sizeof(API(IMAGE_BASE_RELOCATION))) / 2;
       printf("Base relocation: 0x%" PRIX32 " (%d relocations)\n", baseRelocation->virtualAddress, relocationCount);
       uint16_t* relocations = Memory(relocationRva);
       for(unsigned int i = 0; i < relocationCount; i++) {
@@ -3465,11 +3465,11 @@ Exe* LoadExe(const char* path) {
     uint32_t remainingSize = exe->dataDirectories[1].size;
     printf("Import table located at 0x%" PRIX32 "\n", importRva);
     //FIXME: Should be done differently. Import table expects zero element at end which is not checked yet! (it's optional here)
-    while(remainingSize >= sizeof(IMAGE_IMPORT_DESCRIPTOR)) {
+    while(remainingSize >= sizeof(API(IMAGE_IMPORT_DESCRIPTOR))) {
 
       // Access import and check if it is valid
-      IMAGE_IMPORT_DESCRIPTOR* imports = Memory(importRva);
-      if (IsZero(imports, sizeof(IMAGE_IMPORT_DESCRIPTOR))) {
+      API(IMAGE_IMPORT_DESCRIPTOR)* imports = Memory(importRva);
+      if (IsZero(imports, sizeof(API(IMAGE_IMPORT_DESCRIPTOR)))) {
         break;
       }
 
@@ -3494,7 +3494,7 @@ Exe* LoadExe(const char* path) {
           label = malloc(128);
           sprintf(label, "<%s@%d>", name, ordinal);
         } else {
-          IMAGE_IMPORT_BY_NAME* importByName = Memory(exe->peHeader.imageBase + importByNameAddress);
+          API(IMAGE_IMPORT_BY_NAME)* importByName = Memory(exe->peHeader.imageBase + importByNameAddress);
           printf("  0x%" PRIX32 ": 0x%" PRIX16 " '%s' ..", thunkAddress, importByName->hint, importByName->name);
           label = importByName->name;
         }
@@ -3553,8 +3553,8 @@ Exe* LoadExe(const char* path) {
       }
 
       // Jump to next entry
-      importRva += sizeof(IMAGE_IMPORT_DESCRIPTOR);
-      remainingSize -= sizeof(IMAGE_IMPORT_DESCRIPTOR);
+      importRva += sizeof(API(IMAGE_IMPORT_DESCRIPTOR));
+      remainingSize -= sizeof(API(IMAGE_IMPORT_DESCRIPTOR));
     }
   }
 

--- a/windows.h
+++ b/windows.h
@@ -5,20 +5,20 @@
 
 #include "emulation.h"
 
-typedef uint32_t DWORD;
-typedef void VOID;
+typedef uint32_t API(DWORD);
+typedef void API(VOID);
 
-typedef uint32_t UINT; // FIXME: Assumption
-typedef int16_t SHORT; // FIXME: Assumption
+typedef uint32_t API(UINT); // FIXME: Assumption
+typedef int16_t API(SHORT); // FIXME: Assumption
 
 typedef struct {
   uint32_t Data1;
   uint16_t Data2;
   uint16_t Data3;
   uint8_t Data4[8];
-} GUID;
-typedef GUID CLSID;
-typedef GUID IID;
+} API(GUID);
+typedef API(GUID) API(CLSID);
+typedef API(GUID) API(IID);
 
 typedef struct {
   uint32_t bmType;
@@ -28,48 +28,52 @@ typedef struct {
   uint16_t bmPlanes;
   uint16_t bmBitsPixel;
   Address bmBits;
-} BITMAP;
+} API(BITMAP);
 
-typedef DWORD COLORREF;
+typedef API(DWORD) API(COLORREF);
 
-typedef uint32_t SIZE_T;
+typedef uint32_t API(SIZE_T);
 
 typedef struct {
-  DWORD dwLowDateTime;
-  DWORD dwHighDateTime;
-} FILETIME;
+  API(DWORD) dwLowDateTime;
+  API(DWORD) dwHighDateTime;
+} API(FILETIME);
 
-#define MAX_PATH 260
+#define API__MAX_PATH 260
 
-typedef char TCHAR;
+typedef char API(TCHAR);
 typedef struct {
-  DWORD    dwFileAttributes;
-  FILETIME ftCreationTime;
-  FILETIME ftLastAccessTime;
-  FILETIME ftLastWriteTime;
-  DWORD    nFileSizeHigh;
-  DWORD    nFileSizeLow;
-  DWORD    dwReserved0;
-  DWORD    dwReserved1;
-  TCHAR    cFileName[MAX_PATH];
-  TCHAR    cAlternateFileName[14];
-} WIN32_FIND_DATA;
+  API(DWORD)    dwFileAttributes;
+  API(FILETIME) ftCreationTime;
+  API(FILETIME) ftLastAccessTime;
+  API(FILETIME) ftLastWriteTime;
+  API(DWORD)    nFileSizeHigh;
+  API(DWORD)    nFileSizeLow;
+  API(DWORD)    dwReserved0;
+  API(DWORD)    dwReserved1;
+  API(TCHAR)    cFileName[API(MAX_PATH)];
+  API(TCHAR)    cAlternateFileName[14];
+} API(WIN32_FIND_DATA);
 
 typedef struct {
   int x;
-} STR;
-typedef Address LPTSTR;
+} API(STR);
+typedef Address API(LPTSTR);
 
 
-#define VK_SHIFT 0x10
-#define VK_CONTROL 0x11
-#define VK_MENU 0x12
+enum {
+  API(VK_SHIFT) = 0x10,
+  API(VK_CONTROL) = 0x11,
+  API(VK_MENU) = 0x12,
 
-#define VK_LSHIFT 0xA0
-#define VK_RSHIFT 0xA1
-#define VK_LCONTROL 0xA2
-#define VK_RCONTROL 0xA3
-#define VK_LMENU 0xA4
-#define VK_RMENU 0xA5
+  API(VK_CAPITAL) = 0x14,
+
+  API(VK_LSHIFT) = 0xA0,
+  API(VK_RSHIFT) = 0xA1,
+  API(VK_LCONTROL) = 0xA2,
+  API(VK_RCONTROL) = 0xA3,
+  API(VK_LMENU) = 0xA4,
+  API(VK_RMENU) = 0xA5
+};
 
 #endif


### PR DESCRIPTION
This adds a `MS__` prefix to typically Microsoft typenames and constant names.

This is necessary for compilation on Windows where the original typenames of the same name would be present, possibly even with another definition for the target platform.

The proposed prefix is a bit of a misnomer as not only Microsoft functions are prefixed.
If you have better prefix name ideas, please tell me.

The prefixing is currently done with a macro called `MS()` which prefix with `MS__`. In cases where the `MS()` macro can not be used, such as inside macro constants, the `MS__` is manually prefixed.
In some cases the macro constants were put inside an enum to avoid this issue.

---

FIXME:

- Review once more before upstream PR
- Test on windows with latest other changes
- Rename the commit