### PR TITLE
Rework audio

### DIFF
--- a/com/a3d.c
+++ b/com/a3d.c
@@ -257,6 +257,15 @@ HACKY_COM_BEGIN(IA3d4, 0)
   esp += 3 * 4;
 HACKY_COM_END()
 
+// IA3d4 -> STDMETHOD_(ULONG,Release)			(THIS) PURE; // 2
+HACKY_COM_BEGIN(IA3d4, 2)
+  hacky_printf("Release\n");
+  hacky_printf("p 0x%" PRIX32 "\n", stack[1]);
+  //FIXME: Implement
+  eax = 0;
+  esp += 1 * 4;
+HACKY_COM_END()
+
 // IA3d4 -> STDMETHOD(GetHardwareCaps)				(THIS_ LPA3DCAPS_HARDWARE) PURE; // 11
 HACKY_COM_BEGIN(IA3d4, 11)
   hacky_printf("GetHardwareCaps\n");
@@ -864,6 +873,15 @@ HACKY_COM_BEGIN(IA3dSource, 61)
 HACKY_COM_END()
 
 
+
+// IA3dListener -> STDMETHOD_(ULONG,Release)			(THIS) PURE; // 2
+HACKY_COM_BEGIN(IA3dListener, 2)
+  hacky_printf("Release\n");
+  hacky_printf("p 0x%" PRIX32 "\n", stack[1]);
+  //FIXME: Implement
+  eax = 0;
+  esp += 1 * 4;
+HACKY_COM_END()
 
 // IA3dListener -> STDMETHOD(SetPosition3f)		(THIS_ A3DVAL, A3DVAL, A3DVAL) PURE; // 3
 HACKY_COM_BEGIN(IA3dListener, 3)


### PR DESCRIPTION
Here I attempted to add some more audio functionality and I (mostly) failed hard.
Somehow gain values are too low, audio still doesn't pause during menu and various other bugs exist.
Fortunately the audio subsytem can be deactivated in the options, so this is not too critical.

`DuplicateSource` is absolutely horrible. It should - to my understanding - copy all flags). However this is still a lot better than what's in master currently. I'll create a new issue about this after merge.

It also doesn't differentiate between native and 3D sources, which is another big issue.
`SetPanValues` therefore can't be implemented.

Also missing `SetEq`, Doppler stuff and the big one: audio streaming.

FIXME:

- Test AL_SOFT_deferred_updates
- Figure out why some sounds are silent
- Disable audio when a stream event is created. Better than hearing garbage all the time >.<