### PR TITLE
Improve FindUnicorn.cmake

### DIFF
--- a/cmake/FindUnicorn.cmake
+++ b/cmake/FindUnicorn.cmake
@@ -2,15 +2,15 @@
 #  LIBUNICORN_FOUND
 #  LIBUNICORN_INCLUDE_DIR
 #  LIBUNICORN_LIBRARY
-# Hints:
-#  LIBUNICORN_LIBRARY_DIR
 
 find_path(LIBUNICORN_INCLUDE_DIR
-          unicorn/unicorn.h)
+          unicorn/unicorn.h
+          HINTS $ENV{UNICORNDIR}
+          PATH_SUFFIXES include)
 
 find_library(LIBUNICORN_LIBRARY
              NAMES unicorn
-             HINTS "${LIBUNICORN_LIBRARY_DIR}")
+             HINTS $ENV{UNICORNDIR})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(unicorn DEFAULT_MSG


### PR DESCRIPTION
With this change you can set UNICORNDIR to the folder where you built unicorn.
This should make it easier to locate unicorn engine on those platforms, where it isn't installed properly.