### PR TITLE
Introduce a CLA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: cpp
+matrix:
+  include:
+    - os: osx
+      env: NAME="macOS build"
+      sudo: false
+      osx_image: xcode7.3
+      install: "./.travis/macos/install.sh"
+      script: "./.travis/macos/script.sh"
+    - os: linux
+      env: NAME="Ubuntu build"
+      sudo: required
+      dist: trusty
+      services: docker
+      install: "./.travis/ubuntu/install.sh"
+      script: "./.travis/ubuntu/script.sh"
+
+notifications:
+  email: false

--- a/.travis/macos/install.sh
+++ b/.travis/macos/install.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -ex
+
+brew update
+brew install sdl2 unicorn glew openal-soft enet 

--- a/.travis/macos/install.sh
+++ b/.travis/macos/install.sh
@@ -1,4 +1,3 @@
 #!/bin/sh -ex
 
-brew update
 brew install sdl2 unicorn glew openal-soft enet 

--- a/.travis/macos/script.sh
+++ b/.travis/macos/script.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+set -o pipefail
+
+export MACOSX_DEPLOYMENT_TARGET=10.9
+
+mkdir build && cd build
+cmake .. -DCMAKE_OSX_ARCHITECTURES="x86_64;x86_64h" -DCMAKE_BUILD_TYPE=Release
+make -j4

--- a/.travis/ubuntu/docker.sh
+++ b/.travis/ubuntu/docker.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -ex
+
+cd /openswe1r
+
+apt-get update
+apt-get install -y build-essential libsdl2-dev libopenal-dev libenet-dev libglew-dev wget git
+
+# Get a recent version of CMake
+wget -nv https://cmake.org/files/v3.9/cmake-3.9.0-Linux-x86_64.sh
+echo y | sh cmake-3.9.0-Linux-x86_64.sh --prefix=cmake
+export PATH=/openswe1r/cmake/cmake-3.9.0-Linux-x86_64/bin:$PATH
+
+mkdir build && cd build
+
+# Install unicorn from source
+mkdir unicorn
+cd unicorn
+wget -nv https://github.com/unicorn-engine/unicorn/archive/1.0.1.tar.gz
+tar xf 1.0.1.tar.gz --strip-components=1
+UNICORN_ARCHS="x86" ./make.sh
+export UNICORNDIR="`pwd`"
+cd ..
+
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j4

--- a/.travis/ubuntu/install.sh
+++ b/.travis/ubuntu/install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -ex
+
+docker pull ubuntu:16.04

--- a/.travis/ubuntu/script.sh
+++ b/.travis/ubuntu/script.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+docker run -v $(pwd):/openswe1r ubuntu:16.04 /bin/bash -ex /openswe1r/.travis/ubuntu/docker.sh


### PR DESCRIPTION
# This is a dummy PR, the actual PR will contain an updated README instead.

When this is merged we (the OpenSWE1R maintainers) will add a requirement to sign a [Contributor License Agreement (CLA)](https://en.wikipedia.org/wiki/Contributor_License_Agreement#Rationale) for all future PRs to this repository. We'll be using [CLA assistant](https://github.com/cla-assistant/cla-assistant) to enforce it.

[**The planned CLA can be found here.**](https://gist.github.com/JayFoxRox/806f8a50e599985e52bd73e5a7cb1524)

## Reasoning

Having a CLA is beneficial as it allows us to [relicense contributions at a later time](https://en.wikipedia.org/wiki/Software_relicensing).
While this might sound scary to some, we feel that it is a necessity.

History has shown that [Software re-licensing can be a complicated and lengthy process](http://mamedev.org/?p=422). It is often necessary because the original license is not suitable anymore or found to be invalid.

A good example is the GPL incompatibility of the Apple Appstore and similar platforms. If we want to release OpenSWE1R for iOS devices through the platforms official channels in the future, we'd have to make that particular release under another license (like the BSD or MIT licenses). However, we'd have to get permission from every contributor to do so.
Another issue could be compatibilty with platform specific APIs like the Steam "Steamworks" API.
Once multiplayer is implemented, people might also start making changes which won't have to be open-source (as the GPL intends) - switching to an AGPL license would protect us in such cases.
Use in other game engines such as Unity or Unreal-Engine might require the use of the LGPL.

## What will change

Having a CLA allows us to change the license (and dual-license) in the future. The planned CLA will allow us to license all contributions "under the terms of any licenses the Free Software Foundation classifies as Free Software License and which are approved by the Open Source Initiative as Open Source licenses."

We won't have to contact people many years after they made their contributions. Instead, we ask for permission when the contribution is made.

Other people who would want to license OpenSWE1R differently will simply have to ask the maintainers, even when some of the original contributors would be hard or impossible to reach.

---

As legal stuff is boring (and scary), we've tried to keep the agreement as short as possible (We hope we did not accidentally invalidate the CLA in the process or added any new issues 😟 ).

The CLA is currently governed by laws of Germany, simply because that's where I (JayFoxRox), the projects founder, comes from. In the future, that might change to the US as more maintainers join the project.

*We are currently not able to release OpenSWE1R under a non-GPL license anyway. Unicorn, one of our main dependencies, is licensed under the GPL. However, once the need for Unicorn is gone, we might want the option to release OpenSWE1R under a different license for reasons such as those stated above.*

*Also, we do not intend to switch away from the GPL in the foreseeable future. We just want the option of adapting a new license if the circumstances make it necessary.*