### PR TITLE
Implement fog

### DIFF
--- a/com/d3d.h
+++ b/com/d3d.h
@@ -344,6 +344,10 @@ enum {
   API(D3DPTBLENDCAPS_ADD) =              0x00000080L
 };
 
+enum {
+  API(D3DPRASTERCAPS_FOGTABLE) =                 0x00000100L
+};
+
 // Subset of actual type
 typedef enum {
   API(D3DANTIALIAS_NONE)          = 0

--- a/main.c
+++ b/main.c
@@ -378,6 +378,7 @@ GLenum srcBlend;
 bool alphaTest;
 uint32_t fogColor; // ARGB
 bool fogEnable;
+int fogMode;
 float fogStart;
 float fogEnd;
 float projectionMatrix[16];
@@ -421,7 +422,7 @@ static GLenum SetupRenderer(unsigned int primitiveType, unsigned int vertexForma
 
   glUniform1i(glGetUniformLocation(program, "alphaTest"), alphaTest);
 
-  glUniform1i(glGetUniformLocation(program, "fogEnable"), fogEnable);
+  glUniform1i(glGetUniformLocation(program, "fogMode"), fogEnable ? fogMode : API(D3DFOG_NONE));
   glUniform1f(glGetUniformLocation(program, "fogStart"), fogStart);
   glUniform1f(glGetUniformLocation(program, "fogEnd"), fogEnd);
   glUniform3f(glGetUniformLocation(program, "fogColor"),
@@ -2450,6 +2451,7 @@ enum {
   API(D3DPTEXTURECAPS_TRANSPARENCY) =  0x00000008L
 };
 
+
     desc->dpcTriCaps.dwTextureCaps = 0;
     desc->dpcTriCaps.dwTextureCaps |= API(D3DPTEXTURECAPS_PERSPECTIVE);
     desc->dpcTriCaps.dwTextureCaps |= API(D3DPTEXTURECAPS_ALPHA);
@@ -2645,6 +2647,9 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 3)
   desc->dwSize = size;
   desc->dpcTriCaps.dwTextureBlendCaps = 0;
   desc->dpcTriCaps.dwTextureBlendCaps |= API(D3DPTBLENDCAPS_MODULATEALPHA);
+
+  desc->dpcTriCaps.dwTextureBlendCaps = 0;
+  desc->dpcTriCaps.dwRasterCaps |= API(D3DPRASTERCAPS_FOGTABLE);
 
   eax = 0; // FIXME: No idea what this expects to return..
   esp += 3 * 4;
@@ -2920,7 +2925,7 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 22)
 
     case API(D3DRENDERSTATE_FOGTABLEMODE):
       assert((b == API(D3DFOG_NONE)) || (b == API(D3DFOG_LINEAR))); // D3DFOGMODE
-      // FIXME
+      fogMode = b;
       break;
 
     case API(D3DRENDERSTATE_FOGTABLESTART):

--- a/shaders.h
+++ b/shaders.h
@@ -10,10 +10,6 @@ static const char* VertexShader1Texture =
 "\n"
 "uniform mat4 projectionMatrix;\n"
 "\n"
-"uniform bool fogEnable;\n"
-"uniform float fogStart;\n"
-"uniform float fogEnd;\n"
-"uniform vec3 fogColor;\n"
 "uniform vec3 clipScale;\n"
 "uniform vec3 clipOffset;\n"
 "\n"
@@ -40,6 +36,10 @@ static const char* FragmentShader1Texture =
 "\n"
 "uniform sampler2D tex0;\n"
 "uniform bool alphaTest;\n"
+"uniform int fogMode;\n"
+"uniform float fogStart;\n"
+"uniform float fogEnd;\n"
+"uniform vec3 fogColor;\n"
 "\n"
 "in vec4 diffuse;\n"
 "in vec4 specular;\n"
@@ -55,6 +55,15 @@ static const char* FragmentShader1Texture =
 "  color = texture(tex0, uv0);\n"
 "  color *= diffuse;\n"
 "  if (alphaTest && !(int(round(color.a * 255.0)) != 0)) { discard; }\n"
+"  if (fogMode == 0) {\n" // D3DFOG_NONE
+"    color.rgb = color.rgb;\n"
+"  } else if (fogMode == 3) {\n" // D3DFOG_LINEAR
+"    float fogVisibility = (fogEnd - gl_FragCoord.z / gl_FragCoord.w) / (fogEnd - fogStart);\n"
+"    fogVisibility = clamp(fogVisibility, 0.0, 1.0);\n"
+"    color.rgb = mix(fogColor, color.rgb, fogVisibility);\n"
+"  } else {\n" // Unknown fog mode; Signal error by coloring primitive green
+"    color.rgb = vec3(0.0, 1.0, 0.0);\n"
+"  }\n"
 "}\n";
 
 #endif


### PR DESCRIPTION
This PR adds Z-based fog. The fog depth is reconstructed from gl_FragCoord in the pixel shader.
The used formula was not compared to actual hardware or against a D3D6 reference renderer.
However, it's "good enough" for now.

Further testing in the future should be done to confirm these formulas.
There are also [other methods to reconstruct depth](https://www.khronos.org/opengl/wiki/Compute_eye_space_from_window_space), some of which do eye-relative depth which D3D6 also supports (given a compatible ProjectionMatrix).
An issue about this will be created after merge.

![Ando Prime after](https://i.imgur.com/0xDkzAG.png)

More screenshots / comparisons:

* Tatooine: [Before](https://i.imgur.com/QjOOr9n.png) / [After](https://i.imgur.com/8TDv1hK.png)
* Mon Gazza: [Before](https://i.imgur.com/NBkuX3E.png) / [After](https://i.imgur.com/ndUHbOQ.png)
* Ando Prime: [Before](https://i.imgur.com/B2ystgy.png) / [After](https://i.imgur.com/0xDkzAG.png)