### PR TITLE
Gles2 depth readback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 find_package(ENet)
 find_package(Unicorn REQUIRED)
-find_package(OpenGL REQUIRED)
+find_package(OpenGLES2 REQUIRED)
 find_package(SDL2 REQUIRED)
 find_package(OpenAL REQUIRED)
 
@@ -22,7 +22,7 @@ endif()
 
 include_directories(SYSTEM
   ${LIBUNICORN_INCLUDE_DIR}
-  ${OPENGL_INCLUDE_DIR}
+  ${OPENGLES2_INCLUDE_DIR}
   ${SDL2_INCLUDE_DIR}
   ${OPENAL_INCLUDE_DIR}
 )
@@ -58,7 +58,7 @@ if(ENET_FOUND)
 endif()
 
 target_link_libraries(openswe1r
-  ${OPENGL_LIBRARIES}
+  ${OPENGLES2_LIBRARIES}
   ${SDL2_LIBRARY}
   ${OPENAL_LIBRARY}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 find_package(ENet)
 find_package(Unicorn REQUIRED)
 find_package(OpenGL REQUIRED)
-find_package(GLEW REQUIRED)
 find_package(SDL2 REQUIRED)
 find_package(OpenAL REQUIRED)
 
@@ -24,7 +23,6 @@ endif()
 include_directories(SYSTEM
   ${LIBUNICORN_INCLUDE_DIR}
   ${OPENGL_INCLUDE_DIR}
-  ${GLEW_INCLUDE_DIRS}
   ${SDL2_INCLUDE_DIR}
   ${OPENAL_INCLUDE_DIR}
 )
@@ -61,7 +59,6 @@ endif()
 
 target_link_libraries(openswe1r
   ${OPENGL_LIBRARIES}
-  ${GLEW_LIBRARIES}
   ${SDL2_LIBRARY}
   ${OPENAL_LIBRARY}
 )

--- a/cmake/FindOpenGLES2.cmake
+++ b/cmake/FindOpenGLES2.cmake
@@ -1,0 +1,121 @@
+#-------------------------------------------------------------------
+# This file is stolen from part of the CMake build system for OGRE (Object-oriented Graphics Rendering Engine) http://www.ogre3d.org/
+#
+# The contents of this file are placed in the public domain. Feel
+# free to make use of it in any way you like.
+#-------------------------------------------------------------------
+
+# - Try to find OpenGLES and EGL
+# Once done this will define
+#
+#  OPENGLES2_FOUND        - system has OpenGLES
+#  OPENGLES2_INCLUDE_DIR  - the GL include directory
+#  OPENGLES2_LIBRARIES    - Link these to use OpenGLES
+#
+#  EGL_FOUND        - system has EGL
+#  EGL_INCLUDE_DIR  - the EGL include directory
+#  EGL_LIBRARIES    - Link these to use EGL
+
+# Win32, Apple, and Android are not tested!
+# Linux tested and works
+
+if(WIN32)
+	if(CYGWIN)
+		find_path(OPENGLES2_INCLUDE_DIR GLES2/gl2.h)
+		find_library(OPENGLES2_LIBRARY libGLESv2)
+	else()
+		if(BORLAND)
+			set(OPENGLES2_LIBRARY import32 CACHE STRING "OpenGL ES 2.x library for Win32")
+		else()
+			# TODO
+			# set(OPENGLES_LIBRARY ${SOURCE_DIR}/Dependencies/lib/release/libGLESv2.lib CACHE STRING "OpenGL ES 2.x library for win32"
+		endif()
+	endif()
+elseif(APPLE)
+	create_search_paths(/Developer/Platforms)
+	findpkg_framework(OpenGLES2)
+	set(OPENGLES2_LIBRARY "-framework OpenGLES")
+else()
+	find_path(OPENGLES2_INCLUDE_DIR GLES2/gl2.h
+		PATHS /usr/openwin/share/include
+			/opt/graphics/OpenGL/include
+			/opt/vc/include
+			/usr/X11R6/include
+			/usr/include
+	)
+
+	find_library(OPENGLES2_LIBRARY
+		NAMES GLESv2
+		PATHS /opt/graphics/OpenGL/lib
+			/usr/openwin/lib
+			/usr/shlib /usr/X11R6/lib
+			/opt/vc/lib
+			/usr/lib/aarch64-linux-gnu
+			/usr/lib/arm-linux-gnueabihf
+			/usr/lib
+	)
+
+	if(NOT BUILD_ANDROID)
+		find_path(EGL_INCLUDE_DIR EGL/egl.h
+			PATHS /usr/openwin/share/include
+				/opt/graphics/OpenGL/include
+				/opt/vc/include
+				/usr/X11R6/include
+				/usr/include
+		)
+
+		find_library(EGL_LIBRARY
+			NAMES EGL
+			PATHS /opt/graphics/OpenGL/lib
+				/usr/openwin/lib
+				/usr/shlib
+				/usr/X11R6/lib
+				/opt/vc/lib
+				/usr/lib/aarch64-linux-gnu
+				/usr/lib/arm-linux-gnueabihf
+				/usr/lib
+		)
+
+		# On Unix OpenGL usually requires X11.
+		# It doesn't require X11 on OSX.
+
+		if(OPENGLES2_LIBRARY)
+			if(NOT X11_FOUND)
+				include(FindX11)
+			endif()
+			if(X11_FOUND)
+				set(OPENGLES2_LIBRARIES ${X11_LIBRARIES})
+			endif()
+		endif()
+	endif()
+endif()
+
+set(OPENGLES2_LIBRARIES ${OPENGLES2_LIBRARIES} ${OPENGLES2_LIBRARY})
+
+if(BUILD_ANDROID)
+	if(OPENGLES2_LIBRARY)
+		set(EGL_LIBRARIES)
+		set(OPENGLES2_FOUND TRUE)
+	endif()
+else()
+	if(OPENGLES2_LIBRARY AND EGL_LIBRARY)
+		set(OPENGLES2_LIBRARIES ${OPENGLES2_LIBRARY} ${OPENGLES2_LIBRARIES})
+		set(EGL_LIBRARIES ${EGL_LIBRARY} ${EGL_LIBRARIES})
+		set(OPENGLES2_FOUND TRUE)
+	endif()
+endif()
+
+mark_as_advanced(
+	OPENGLES2_INCLUDE_DIR
+	OPENGLES2_LIBRARY
+	EGL_INCLUDE_DIR
+	EGL_LIBRARY
+)
+
+if(OPENGLES2_FOUND)
+	message(STATUS "Found system OpenGL ES 2 library: ${OPENGLES2_LIBRARIES}")
+else()
+	set(OPENGLES2_LIBRARIES "")
+endif()
+
+

--- a/com/d3d.h
+++ b/com/d3d.h
@@ -14,6 +14,7 @@ typedef struct {
   void* vtable;
   Address surface;
   GLuint handle;
+  bool swizzle;
 } API(Direct3DTexture2);
 
 typedef struct {

--- a/main.c
+++ b/main.c
@@ -3942,14 +3942,6 @@ int main(int argc, char* argv[]) {
 	  assert(glcontext != NULL);
 
 
-    //FIXME: This is ugly but gets the job done.. for now
-    static GLuint vao = 0;
-    if (vao == 0) {
-      glGenVertexArrays(1, &vao);
-    }
-    glBindVertexArray(vao);
-
-
     glDisable(GL_CULL_FACE);
 //    glDepthFunc(GL_GEQUAL);
     glCullFace(GL_FRONT);    

--- a/main.c
+++ b/main.c
@@ -3116,7 +3116,8 @@ HACKY_COM_BEGIN(IDirect3DTexture2, 5)
   API(Direct3DTexture2)* this = Memory(stack[1]);
   API(Direct3DTexture2)* a = Memory(stack[2]);
   //FIXME: Dirty hack..
-  this->handle = a->handle;
+  memcpy(this, a, sizeof(API(Direct3DTexture2)));
+
   eax = 0; // FIXME: No idea what this expects to return..
   esp += 2 * 4;
 HACKY_COM_END()

--- a/main.c
+++ b/main.c
@@ -24,7 +24,7 @@
 #include "SDL.h"
 static SDL_Window* sdlWindow;
 
-#include <GL/glew.h>
+#include <GLES2/gl2.h>
 
 #include "com/d3d.h"
 #include "com/ddraw.h"
@@ -327,7 +327,7 @@ static void UcCrashHook(void* uc, uint64_t address, uint32_t size, void* user_da
   sprintf(buf, "Bug: ecx=0x%08" PRIX32 ", at eip=0x%08" PRIX32 ". 0x%08" PRIX32 " 0x%08" PRIX32 " 0x%08" PRIX32 " 0x%08" PRIX32,
           ecx, eip,
           stack[0], stack[1], stack[2], stack[3]);
-  glDebugMessageInsert(GL_DEBUG_SOURCE_APPLICATION, GL_DEBUG_TYPE_MARKER, 0, GL_DEBUG_SEVERITY_NOTIFICATION, -1, buf);
+//  glDebugMessageInsert(GL_DEBUG_SOURCE_APPLICATION, GL_DEBUG_TYPE_MARKER, 0, GL_DEBUG_SEVERITY_NOTIFICATION, -1, buf);
 }
 
 static void PrintVertices(unsigned int vertexFormat, Address address, unsigned int count) {
@@ -432,7 +432,7 @@ static GLenum SetupRenderer(unsigned int primitiveType, unsigned int vertexForma
   glUniform3fv(glGetUniformLocation(program, "clipScale"), 1, clipScale);
   glUniform3fv(glGetUniformLocation(program, "clipOffset"), 1, clipOffset);
 
-#if 1
+#if 0 //FIXME!!
   // Hack to disable texture if tex0 is used - doesn't work?!
   if (texCount == 0) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_ONE);
@@ -1200,7 +1200,7 @@ HACKY_IMPORT_BEGIN(StretchBlt)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, stack[4], stack[5], 0, GL_BGR, GL_UNSIGNED_BYTE, data);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, stack[4], stack[5], 0, GL_RGB, GL_UNSIGNED_BYTE, data);
     glBindTexture(GL_TEXTURE_2D, previousTexture);
   } else {
 
@@ -2370,12 +2370,19 @@ HACKY_COM_BEGIN(IDirectDrawSurface4, 32)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
   if (desc->ddpfPixelFormat.dwRGBBitCount == 32) {
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, desc->dwWidth, desc->dwHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, Memory(desc->lpSurface));
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, desc->dwWidth, desc->dwHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, Memory(desc->lpSurface));
   } else {
     if (desc->ddpfPixelFormat.dwRGBAlphaBitMask == 0x8000) {
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, desc->dwWidth, desc->dwHeight, 0, GL_BGRA, GL_UNSIGNED_SHORT_1_5_5_5_REV, Memory(desc->lpSurface));
+      //FIXME: Do this properly [buffer size + how copy size is calculated etc]
+      uint16_t swap_buffer[1024*1024];
+      unsigned int c = desc->dwWidth * desc->dwHeight;
+      memcpy(swap_buffer, Memory(desc->lpSurface), 2 * c);
+      for(unsigned int i = 0; i < c; i++) {
+        swap_buffer[i] = (swap_buffer[i] << 1) | (swap_buffer[i] >> 15);
+      }
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, desc->dwWidth, desc->dwHeight, 0, GL_RGBA, GL_UNSIGNED_SHORT_5_5_5_1, swap_buffer);
     } else {
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, desc->dwWidth, desc->dwHeight, 0, GL_BGRA, GL_UNSIGNED_SHORT_4_4_4_4_REV, Memory(desc->lpSurface));
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, desc->dwWidth, desc->dwHeight, 0, GL_RGBA, GL_UNSIGNED_SHORT_4_4_4_4, Memory(desc->lpSurface));
     }
   }
   glBindTexture(GL_TEXTURE_2D, previousTexture);
@@ -3181,7 +3188,7 @@ HACKY_COM_BEGIN(IDirect3DViewport3, 20)
     float b = (clearColor & 0xFF) / 255.0f;
 
     glClearStencil(stencilValue);
-    glClearDepth(zValue);
+    glClearDepthf(zValue);
     glClearColor(r, g, b, a);
     glClear(((flags & API(D3DCLEAR_TARGET)) ? GL_COLOR_BUFFER_BIT : 0) |
             ((flags & API(D3DCLEAR_ZBUFFER)) ? GL_DEPTH_BUFFER_BIT : 0) |
@@ -3913,9 +3920,9 @@ int main(int argc, char* argv[]) {
 		  style |= SDL_WINDOW_FULLSCREEN;
     }
 
-	  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-	  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-	  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+	  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+	  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+	  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 	  SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 	  SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
 	  SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
@@ -3925,13 +3932,6 @@ int main(int argc, char* argv[]) {
 
 	  SDL_GLContext glcontext = SDL_GL_CreateContext(sdlWindow);
 	  assert(glcontext != NULL);
-
-    glewExperimental = GL_TRUE;
-    GLenum err = glewInit();
-    if (err != GLEW_OK) {
-      fprintf(stderr, "Error: %s\n", glewGetErrorString(err));
-      return 1;
-    }
 
 
     //FIXME: This is ugly but gets the job done.. for now

--- a/shader.h
+++ b/shader.h
@@ -7,7 +7,7 @@
 
 #include <stdbool.h>
 
-#include <GL/glew.h>
+#include <GLES2/gl2.h>
 
 void PrintShaderLog(GLuint shader);
 void PrintShaderProgramLog(GLuint program);

--- a/shaders.h
+++ b/shaders.h
@@ -59,6 +59,24 @@ static const char* FragmentShader1Texture =
 "  }\n"
 "  color *= diffuse;\n"
 "  if (alphaTest && !(int(round(color.a * 255.0)) != 0)) { discard; }\n"
+#define SHADERS_DEPTH_4_4_4_4
+#ifdef SHADERS_DEPTH_4_4_4_4
+"  #define fmodf(x, y) mod(x, y)\n"
+"  highp float depth = float(0x1fCa) / float(0xFFFF);\n" // 1.0 - gl_FragCoord.z * gl_FragCoord.w;\n"
+"  highp float v = depth;\n"
+"  v *= float(0x100) - 1.0/float(0x100);\n"
+"  v /= float(0x10);\n"
+"  highp float r = fmodf(v, float(0x10));\n"
+"  v *= float(0x10);\n"
+"  highp float g = fmodf(v, float(0x10));\n"
+"  v = fmodf(v, 1.0);\n"
+"  v *= float(0x10);\n"
+"  highp float b = fmodf(v, float(0x10));\n"
+"  v *= float(0x10);\n"
+"  highp float a = fmodf(v, float(0x10));\n"
+"  color = vec4(r / 16.0, g / 16.0, b / 16.0, a / 16.0);\n"
+//"color = vec4(depth);\n"
+#endif
 "}\n";
 
 #endif

--- a/shaders.h
+++ b/shaders.h
@@ -40,6 +40,7 @@ static const char* FragmentShader1Texture =
 "\n"
 "uniform sampler2D tex0;\n"
 "uniform bool alphaTest;\n"
+"uniform bool textureSwizzle;\n"
 "\n"
 "varying lowp vec4 diffuse;\n"
 "varying lowp vec4 specular;\n"
@@ -53,6 +54,9 @@ static const char* FragmentShader1Texture =
 "\n"
 "void main() {\n"
 "  color = texture2D(tex0, uv0);\n"
+"  if (textureSwizzle) {\n"
+"    color = color.gbar;\n"
+"  }\n"
 "  color *= diffuse;\n"
 "  if (alphaTest && !(int(round(color.a * 255.0)) != 0)) { discard; }\n"
 "}\n";

--- a/shaders.h
+++ b/shaders.h
@@ -6,7 +6,7 @@
 #define __OPENSWE1R_SHADERS_H__
 
 static const char* VertexShader1Texture =
-"#version 330\n"
+"#version 100\n"
 "\n"
 "uniform mat4 projectionMatrix;\n"
 "\n"
@@ -17,14 +17,14 @@ static const char* VertexShader1Texture =
 "uniform vec3 clipScale;\n"
 "uniform vec3 clipOffset;\n"
 "\n"
-"in vec4 positionIn;\n"
-"in vec4 diffuseIn;\n"
-"in vec4 specularIn;\n"
-"in vec2 uv0In;\n"
+"attribute vec4 positionIn;\n"
+"attribute vec4 diffuseIn;\n"
+"attribute vec4 specularIn;\n"
+"attribute vec2 uv0In;\n"
 "\n"
-"out vec4 diffuse;\n"
-"out vec4 specular;\n"
-"out vec2 uv0;\n"
+"varying vec4 diffuse;\n"
+"varying vec4 specular;\n"
+"varying vec2 uv0;\n"
 "\n"
 "void main() {\n"
 "  gl_Position = vec4(positionIn.xyz * clipScale + clipOffset, 1.0);\n"
@@ -36,23 +36,23 @@ static const char* VertexShader1Texture =
 "}";
 
 static const char* FragmentShader1Texture =
-"#version 330\n"
+"#version 100\n"
 "\n"
 "uniform sampler2D tex0;\n"
 "uniform bool alphaTest;\n"
 "\n"
-"in vec4 diffuse;\n"
-"in vec4 specular;\n"
-"in vec2 uv0;\n"
+"varying lowp vec4 diffuse;\n"
+"varying lowp vec4 specular;\n"
+"varying highp vec2 uv0;\n"
 "\n"
-"out vec4 color;\n"
+"#define color gl_FragColor\n"
 #if 0
 "\n"
 "uniform sampler2D tex0;\n"
 #endif
 "\n"
 "void main() {\n"
-"  color = texture(tex0, uv0);\n"
+"  color = texture2D(tex0, uv0);\n"
 "  color *= diffuse;\n"
 "  if (alphaTest && !(int(round(color.a * 255.0)) != 0)) { discard; }\n"
 "}\n";


### PR DESCRIPTION
Extension of #30 

Problem: Weird overflows between values and readback must be 8888

Solution (??!?): Claim to have a 16 bit framebuffer but only use ~8 bit (with carefully crafted factors / modulos). Then use a FBO which is only half as wide as the original buffer, so each Z-Buffer pixel outputs 2 pixels (or 32 bit).

---

Many other issues exist too. Performance should probably be checked before work on this continues.